### PR TITLE
stat_cache_delete on file 404

### DIFF
--- a/src/ldb-filecache.c
+++ b/src/ldb-filecache.c
@@ -437,6 +437,11 @@ static int ldb_get_fresh_fd(ldb_filecache_t *cache,
         }
         else if (code == 404) {
             log_print(LOG_WARNING, "ldb_get_fresh_fd: File expected to exist returns 404.");
+            /* we get a 404 because the stat_cache returned that the file existed, but it
+             * was not on the server. Deleting it from the stat_cache makes the stat_cache
+             * consistent, so the next access to the file will be handled correctly.
+             */
+            stat_cache_delete(cache, path);
             ret = -ENOENT;
         }
         else {


### PR DESCRIPTION
This doesn't solve the problem at the point that we see it. However, a subsequent access to the file will find the stat cache and the file server in sync. If you try to create a file which you think doesn't exist, but it used to in some context and is in the stat cache, fuse will go forth assuming the file exists and not let you create it; then when you open a "pre-existing" file, you will get this error. We have seen this pattern in infinite loops. This fix should at least prevent the infinite loop.
