### PR TITLE
Timing on propfinds; capture long operations

### DIFF
--- a/src/filecache.c
+++ b/src/filecache.c
@@ -369,8 +369,8 @@ static void get_fresh_fd(filecache_t *cache,
     static __thread long sglatency = 0;
     static __thread time_t sgtime = 0;
     // Not to exceed time for operation, else it's an error. Allow large files a longer time
-    static const unsigned small_time_allotment = 4000; // 4 seconds
-    static const unsigned large_time_allotment = 16000; // 16 seconds
+    static const unsigned small_time_allotment = 2000; // 2 seconds
+    static const unsigned large_time_allotment = 8000; // 8 seconds
 
     BUMP(filecache_fresh_fd);
 
@@ -999,8 +999,8 @@ static void put_return_etag(const char *path, int fd, char *etag, GError **gerr)
     static __thread long splatency = 0;
     static __thread time_t sptime = 0;
     // Not to exceed time for operation, else it's an error. Allow large files a longer time
-    static const unsigned small_time_allotment = 4000; // 4 seconds
-    static const unsigned large_time_allotment = 16000; // 16 seconds
+    static const unsigned small_time_allotment = 2000; // 2 seconds
+    static const unsigned large_time_allotment = 8000; // 8 seconds
 
     BUMP(filecache_return_etag);
 

--- a/src/fusedav.c
+++ b/src/fusedav.c
@@ -109,7 +109,7 @@ static int simple_propfind_with_redirect(
     static __thread time_t time = 0;
     unsigned long exceeded_count = 0;
     // Alert on propfind taking longer than 10 seconds
-    static const unsigned propfind_time_allotment = 10000; // 10 seconds
+    static const unsigned propfind_time_allotment = 4000; // 4 seconds
     int ret;
 
     log_print(LOG_DEBUG, SECTION_FUSEDAV_STAT, "simple_propfind_with_redirect: Performing (%s) PROPFIND of depth %d on path %s.", last_updated > 0 ? "progressive" : "complete", depth, path);


### PR DESCRIPTION
We have had fusedav stats on count and latency of GET and PUT; here we add PROPFIND.
We will also capture operations which take a long time and graph them. The graphs are part of a titan commit. I have chosen 4 seconds for small GET and PUT and 16 for large; 10 for PROPFIND. These are just guesses and can be adjusted as we see how things work out in the wild.
