### PR TITLE
Update tls

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -89,10 +89,7 @@ struct addr_score_s {
     unsigned int score;
 };
 
-// Should equal the minimum number of nodes in a valhalla cluster.
 // It needs some value to start, but will be adjusted in call to getaddrinfo
-// NB. Currently hard-coded to 3. We want to prevent overwhelming server in
-// case of sick server nodes.
 // If one node is unresponsive, we will rescramble the resolve list and
 // expect a different node to try the second time. This will clear the thread
 // of continuing to target a bad node.
@@ -783,6 +780,15 @@ CURL *session_request_init(const char *path, const char *query_string, bool temp
     //curl_easy_setopt(session, CURLOPT_LOW_SPEED_TIME, 60);
     curl_easy_setopt(session, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
     curl_easy_setopt(session, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+
+    // For curl configured for nss rather than openssl
+    // curl-config --configure ... '--without-ssl' '--with-nss'
+    // cipher list for nss at:
+    // https://git.fedorahosted.org/cgit/mod_nss.git/plain/docs/mod_nss.html
+    // Restrict to TLSv1.2
+    // Prefer gcm, but allow lesser cipher
+    curl_easy_setopt(session, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+    curl_easy_setopt(session, CURLOPT_SSL_CIPHER_LIST, "ecdhe_rsa_aes_128_gcm_sha_256");
 
     error = construct_resolve_slist(session, new_slist);
     /* If we get an error from construct_resolve_slist, we didn't set up the


### PR DESCRIPTION
@kibra
I would like to update fusedav to use TLSv1.2 and cipher ECDHE-RSA-AES128-GCM-SHA256 to connect to Valhalla.
Some notes at:
https://getpantheon.atlassian.net/wiki/display/VULCAN/Fusedav+-+Valhalla+Encryption
Companion titan PR:
https://github.com/pantheon-systems/titan-mt/pull/11862
