### PR TITLE
Add saint mode state machine and support one-thread-at-a-time saintmo…

### DIFF
--- a/src/props.c
+++ b/src/props.c
@@ -347,6 +347,8 @@ int simple_propfind(const char *path, size_t depth, time_t last_updated, props_r
         if (!session || inject_error(props_error_spropfindsession)) {
             g_set_error(gerr, props_quark(), ENETDOWN, "simple_propfind(%s): failed to get request session", path);
             free(query_string);
+            // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
+            try_release_request_outstanding();
             goto finish;
         }
 
@@ -402,11 +404,12 @@ int simple_propfind(const char *path, size_t depth, time_t last_updated, props_r
     if (res != CURLE_OK || response_code >= 500 || inject_error(props_error_spropfindcurl)) {
         log_print(LOG_ERR, SECTION_PROPS_DEFAULT, "simple_propfind: (%s) PROPFIND failed: %s rc: %lu",
             last_updated > 0 ? "progressive" : "complete", curl_easy_strerror(res), response_code);
-        // Go into saint mode.
-        set_saint_mode();
+        trigger_saint_event(CLUSTER_FAILURE);
         set_dynamic_logging();
         g_set_error(gerr, props_quark(), ENETDOWN, "simple_propfind(%s): failed, ENETDOWN", path);
         goto finish;
+    } else {
+        trigger_saint_event(CLUSTER_SUCCESS);
     }
 
     // injected error props_error_spropfindunkcode will fall through to the else clause

--- a/src/session.c
+++ b/src/session.c
@@ -46,6 +46,18 @@
 static pthread_once_t session_once = PTHREAD_ONCE_INIT;
 static pthread_key_t session_tsd_key;
 
+pthread_mutex_t saint_state_mutex = PTHREAD_MUTEX_INITIALIZER;
+static state_t saint_state = STATE_HEALTHY;
+
+pthread_mutex_t request_outstanding = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+static int request_outstanding_lock_count = 0;
+
+void (*const state_table [NUM_STATES][NUM_EVENTS]) (void) = {
+    { action_s1_e1, action_s1_e2, action_s1_e3 }, /* procedures for state 1 */
+    { action_s2_e1, action_s2_e2, action_s2_e3 }, /* procedures for state 2 */
+    { action_s3_e1, action_s3_e2, action_s3_e3 }  /* procedures for state 3 */
+};
+
 // The string we pass to curl is domain:port:ip:address, so leave room
 #define IPSTR_SZ 128
 // Maximum number of A records (bzw IP addresses) our domain can resolve to
@@ -217,6 +229,9 @@ static void handle_cleanup(void *s) {
 // When a thread exits, we also want to free its hashtable. We don't want to free the hashtable if we are just
 // reinitializing the thread, since we want to keep the health status that causes those reinitializations
 static void session_destroy(void *s) {
+    pthread_mutex_lock(&saint_state_mutex);
+    try_release_request_outstanding();
+    pthread_mutex_unlock(&saint_state_mutex);
     handle_cleanup(s);
     g_hash_table_destroy(node_status.node_hash_table);
 }
@@ -446,35 +461,99 @@ static bool set_health_status(char *addr, char *curladdr) {
  * Regarding (2), propfinds should succeed, as should GETs (as if 304).
  */
 // cluster_failure_timestamp is the most recent time we detected that all connections to the cluster were in some failed mode
-pthread_mutex_t last_failure_mutex = PTHREAD_MUTEX_INITIALIZER;
 static time_t failure_timestamp = 0;
 // Backoff time; avoid accessing the cluster for this many seconds
 const int saint_mode_duration = 10;
 
-bool use_saint_mode(void) {
-    struct timespec now;
-    bool use_saint;
-    if (!config_grace) return false;
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    pthread_mutex_lock(&last_failure_mutex);
-    use_saint = (failure_timestamp + saint_mode_duration >= now.tv_sec);
-    pthread_mutex_unlock(&last_failure_mutex);
-    return use_saint;
+void try_release_request_outstanding(void) {
+    if (pthread_mutex_trylock(&request_outstanding) == 0) {
+        log_print(LOG_DEBUG, SECTION_FUSEDAV_DEFAULT, "Release lock for request_outstanding, lock_count: %d", request_outstanding_lock_count);
+        for (int i = 0; i < request_outstanding_lock_count; i++) {
+            pthread_mutex_unlock(&request_outstanding);
+        }
+        request_outstanding_lock_count = 0;
+        pthread_mutex_unlock(&request_outstanding);
+    }
 }
 
-void set_saint_mode(void) {
+void action_s1_e1(void) {
     struct timespec now;
-    if (!config_grace) return;
-    // First log for metrics; second for logs
-    log_print(LOG_INFO, SECTION_ENHANCED,
-        "Setting cluster saint mode for %lu seconds. fusedav.saint_mode:1|c", saint_mode_duration);
-    log_print(LOG_ERR, SECTION_FUSEDAV_DEFAULT,
-        "Setting cluster saint mode for %lu seconds.", saint_mode_duration);
     clock_gettime(CLOCK_MONOTONIC, &now);
-    pthread_mutex_lock(&last_failure_mutex);
     failure_timestamp = now.tv_sec;
-    pthread_mutex_unlock(&last_failure_mutex);
+    saint_state = STATE_SAINT_MODE;
+    log_print(LOG_NOTICE, SECTION_FUSEDAV_DEFAULT, "Event CLUSTER_FAILURE; transitioned to STATE_SAINT_MODE from STATE_HEALTHY.");
 }
+void action_s1_e2 (void) {}
+void action_s1_e3 (void) {}
+void action_s2_e1 (void) {}
+void action_s2_e2 (void) {
+    saint_state = STATE_ATTEMPTING_TO_EXIT_SAINT_MODE;
+    log_print(LOG_NOTICE, SECTION_FUSEDAV_DEFAULT, "Event SAINT_MODE_DURATION_EXPIRED; transitioned to STATE_ATTEMPTING_TO_EXIT_SAINT_MODE from STATE_SAINT_MODE.");
+}
+void action_s2_e3 (void) {}
+void action_s3_e1 (void) {
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    failure_timestamp = now.tv_sec;
+    try_release_request_outstanding();
+    saint_state = STATE_SAINT_MODE;
+    log_print(LOG_INFO, SECTION_ENHANCED, "Setting cluster saint mode for %lu seconds. fusedav.saint_mode:1|c", saint_mode_duration);
+    log_print(LOG_NOTICE, SECTION_FUSEDAV_DEFAULT, "Event CLUSTER_FAILURE; transitioned to STATE_SAINT_MODE from STATE_ATTEMPTING_TO_EXIT_SAINT_MODE.");
+}
+void action_s3_e2 (void) {}
+void action_s3_e3 (void) {
+    try_release_request_outstanding();
+    saint_state = STATE_HEALTHY;
+    log_print(LOG_NOTICE, SECTION_FUSEDAV_DEFAULT, "Event CLUSTER_SUCCESS; transitioned to STATE_HEALTHY from STATE_ATTEMPTING_TO_EXIT_SAINT_MODE.");
+}
+
+
+void trigger_saint_mode_expired_if_needed(void) {
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    if (saint_state == STATE_SAINT_MODE && now.tv_sec >= failure_timestamp + saint_mode_duration)
+        state_table[saint_state][SAINT_MODE_DURATION_EXPIRED]();
+}
+
+void trigger_saint_event(event_t event) {
+    if (!config_grace) return;
+    pthread_mutex_lock(&saint_state_mutex);
+    trigger_saint_mode_expired_if_needed(); // trigger SAINT_MODE_DURATION_EXPIRED if duration has expired.
+    state_table[saint_state][event]();
+    pthread_mutex_unlock(&saint_state_mutex);
+}
+
+state_t get_saint_state(void) {
+    pthread_mutex_lock(&saint_state_mutex);
+    trigger_saint_mode_expired_if_needed();
+    pthread_mutex_unlock(&saint_state_mutex);
+    return saint_state;
+}
+
+bool use_saint_mode(void) {
+    bool sm = false;
+    pthread_mutex_lock(&saint_state_mutex);
+    trigger_saint_mode_expired_if_needed();
+
+    if (saint_state == STATE_HEALTHY) {
+        sm = false;
+    } else if (saint_state == STATE_SAINT_MODE) {
+        sm = true;
+    } else if (saint_state == STATE_ATTEMPTING_TO_EXIT_SAINT_MODE) {
+        if (pthread_mutex_trylock(&request_outstanding) == 0) {
+            request_outstanding_lock_count++;
+            log_print(LOG_DEBUG, SECTION_FUSEDAV_DEFAULT, "Aquire lock for request_outstanding, lock_count: %d", request_outstanding_lock_count);
+            sm = false;
+        } else {
+            log_print(LOG_DEBUG, SECTION_FUSEDAV_DEFAULT, "Failed to aquire request_outstanding, using saint_mode");
+            sm = true;
+        }
+    }
+
+    pthread_mutex_unlock(&saint_state_mutex);
+    return sm;
+}
+
 
 /* For reference, keep the different sockaddr structs available for inspection
  *

--- a/src/session.h
+++ b/src/session.h
@@ -38,7 +38,23 @@ void aggregate_log_print_local(unsigned int log_level, unsigned int section, con
     const char *description1, unsigned long *count1, unsigned long value1,
     const char *description2, long *count2, long value2);
 
-void set_saint_mode(void);
+typedef enum { STATE_HEALTHY, STATE_SAINT_MODE, STATE_ATTEMPTING_TO_EXIT_SAINT_MODE, NUM_STATES } state_t;
+typedef enum { CLUSTER_FAILURE, SAINT_MODE_DURATION_EXPIRED, CLUSTER_SUCCESS, NUM_EVENTS } event_t;
+
+void action_s1_e1 (void);
+void action_s1_e2 (void);
+void action_s1_e3 (void);
+void action_s2_e1 (void);
+void action_s2_e2 (void);
+void action_s2_e3 (void);
+void action_s3_e1 (void);
+void action_s3_e2 (void);
+void action_s3_e3 (void);
+
+void try_release_request_outstanding(void);
+void trigger_saint_mode_expired_if_needed(void);
+void trigger_saint_event(event_t);
+state_t get_saint_state(void);
 bool use_saint_mode(void);
 
 #endif


### PR DESCRIPTION
This implements a state machine for entering/exiting saint mode as well as the logic to support one-thread-at-a-time cluster access when attempting to leave saint mode.

This go script was very helpful in both 1) identifying the problem with the current saint mode and 2) verifying that this new code fixes the problems we were seeing.
https://gist.github.com/kibra/ea3516ef311cbcb92ed4

In addition to this fusedav code, I found it necessary to have *at least two* nginx workers so that nginx doesn't get locked up on the single thread trying to exit saint mode:
https://github.com/pantheon-systems/titan-mt/pull/13213

Ping @jerryblakley