### PR TITLE
Log when curl_easy_init returns NULL

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -1214,7 +1214,10 @@ static CURL *update_session(GHashTable *addr_table, bool tmp_session) {
     }
     else {
         session = curl_easy_init();
-        if (!session) return NULL;
+        if (!session) {
+            log_print(LOG_CRIT, SECTION_SESSION_DEFAULT, "%s: curl_easy_init returns NULL");
+            return NULL;
+        }
         // We don't want a tmp session to muck with start time and resetting the main session
         if (!tmp_session) {
             // Keep track of start time so we can track how long sessions stay open

--- a/tests/saintmode-nginx.sh
+++ b/tests/saintmode-nginx.sh
@@ -18,6 +18,7 @@ EOF
 
 verbose=0
 iters=0
+noonebox=0
 
 while getopts "hi:ov" OPTION
 do


### PR DESCRIPTION
I saw a couple of cases where we see a NULL session without knowing why. Add this to help track.