### PR TITLE
Call getaddrinfo less often

### DIFF
--- a/src/filecache.c
+++ b/src/filecache.c
@@ -330,8 +330,7 @@ static size_t capture_etag(void *ptr, size_t size, size_t nmemb, void *userdata)
         if (value_len > ETAG_MAX)
             goto finish;
 
-        strncpy(etag, value, value_len);
-        etag[value_len - 1] = '\0';
+        g_strlcpy(etag, value, value_len);
     }
 
 finish:
@@ -593,18 +592,17 @@ static void get_fresh_fd(filecache_t *cache,
             }
         }
         else {
-            strncpy(old_filename, pdata->filename, PATH_MAX);
+            g_strlcpy(old_filename, pdata->filename, PATH_MAX);
             unlink_old = true;
         }
 
         // Fill in ETag.
         log_print(LOG_DEBUG, SECTION_FILECACHE_OPEN, "Saving ETag: %s", etag);
-        strncpy(pdata->etag, etag, ETAG_MAX);
-        pdata->etag[ETAG_MAX] = '\0'; // length of etag is ETAG_MAX + 1 to accomodate this null terminator
+        g_strlcpy(pdata->etag, etag, ETAG_MAX + 1);
 
         // Point the persistent cache to the new file content.
         pdata->last_server_update = time(NULL);
-        strncpy(pdata->filename, response_filename, PATH_MAX);
+        g_strlcpy(pdata->filename, response_filename, PATH_MAX);
 
         sdata->fd = response_fd;
 
@@ -1335,7 +1333,7 @@ bool filecache_sync(filecache_t *cache, const char *path, struct fuse_file_info 
         }
         else {
             // If we don't PUT the file, we don't have an etag, so zero it out
-            strncpy(pdata->etag, "", 1);
+            g_strlcpy(pdata->etag, "", 1);
 
             // The local copy currently trumps the server one, no matter how old.
             pdata->last_server_update = 0;
@@ -1713,7 +1711,7 @@ void filecache_cleanup(filecache_t *cache, const char *cache_path, bool first, G
             ++cached_files;
             // We delete the entry, making pdata invalid, before we might need the filename to unlink,
             // so store it in fname
-            strncpy(fname, pdata->filename, PATH_MAX);
+            g_strlcpy(fname, pdata->filename, PATH_MAX);
 
             // If the cache file doesn't exist, delete the entry from the level_db cache
             ret = access(fname, F_OK);

--- a/src/fusedav.c
+++ b/src/fusedav.c
@@ -247,9 +247,10 @@ static void getdir_propfind_callback(__unused void *userdata, const char *path, 
                 timed_curl_easy_perform(session, &res, &response_code, &elapsed_time);
 
                 process_status(funcname, session, res, response_code, elapsed_time, idx, path, tmp_session);
-            }
 
-            delete_tmp_session(session);
+                delete_tmp_session(session);
+                session = NULL;
+            }
 
             if(res != CURLE_OK || response_code >= 500 || inject_error(fusedav_error_propfindhead)) {
                 trigger_saint_event(CLUSTER_FAILURE);

--- a/src/props.c
+++ b/src/props.c
@@ -93,8 +93,7 @@ static char *get_relative_path(UriUriA *base_uri, UriUriA *source_uri) {
     while (cur != NULL) {
         segment_len = cur->text.afterLast - cur->text.first;
         segment = malloc(segment_len + 1);
-        strncpy(segment, cur->text.first, segment_len);
-        segment[segment_len] = '\0';
+        g_strlcpy(segment, cur->text.first, segment_len);
 
         if (path == NULL) {
             path = segment;
@@ -182,7 +181,7 @@ static void characterDataHandler(void *userData, const XML_Char *s, int len) {
     state->estate.current_data = realloc(state->estate.current_data, state->estate.current_data_len + len);
 
     // Copy in the new data, starting by overwriting the NUL terminator.
-    strncpy(state->estate.current_data + state->estate.current_data_len - 1, s, len);
+    g_strlcpy(state->estate.current_data + state->estate.current_data_len - 1, s, len);
 
     // Update the string length.
     state->estate.current_data_len += len;
@@ -206,8 +205,7 @@ static void endElement(void *userData, const XML_Char *name) {
         unescaped_path = curl_easy_unescape(state->session, path, 0, NULL);
         free(path);
         log_print(LOG_INFO, SECTION_PROPS_DEFAULT, "DAV:href: %s", state->estate.current_data);
-        strncpy(state->rstate.path, unescaped_path, PATH_MAX);
-        state->rstate.path[PATH_MAX - 1] = '\0';
+        g_strlcpy(state->rstate.path, unescaped_path, PATH_MAX);
         free(unescaped_path);
     }
     else if (strcmp(name, "DAV:collection") == 0) {
@@ -295,8 +293,7 @@ static size_t write_parsing_callback(void *contents, size_t length, size_t nmemb
             char failure_str[PARSE_FAILURE_STR_SIZE + 1];
             failure_str[0] = '\0';
             if (contents) {
-                strncpy(failure_str, contents, PARSE_FAILURE_STR_SIZE);
-                failure_str[PARSE_FAILURE_STR_SIZE] = '\0';
+                g_strlcpy(failure_str, contents, PARSE_FAILURE_STR_SIZE + 1);
             }
             log_print(LOG_NOTICE, SECTION_PROPS_DEFAULT, "write_parsing_callback: Parsing response buffer of length %u failed with error: %s -- return string: %s", real_size, XML_ErrorString(error_code), failure_str);
             state->failure = true;

--- a/src/session.c
+++ b/src/session.c
@@ -708,7 +708,7 @@ static bool set_health_status(char *addr, char *curladdr) {
         }
         else {
             log_print(LOG_NOTICE, SECTION_SESSION_DEFAULT, 
-                    "%s: new entry doesn't have curladdr %s", addr);
+                    "%s: new entry doesn't have curladdr %s", funcname, addr);
         }
         g_hash_table_replace(node_status.node_hash_table, g_strdup(addr), health_status);
         log_print(LOG_INFO, SECTION_SESSION_DEFAULT, 
@@ -718,7 +718,7 @@ static bool set_health_status(char *addr, char *curladdr) {
     return added_entry;
 }
 
-static void construct_resolve_slist(GHashTable *addr_table, bool new_session) {
+static void construct_resolve_slist(GHashTable *addr_table) {
     static const char *funcname = "construct_resolve_slist";
     int addr_score_idx = 0;
     GHashTableIter iter;
@@ -726,10 +726,7 @@ static void construct_resolve_slist(GHashTable *addr_table, bool new_session) {
     // Did we change the list? Used to decide to print new list
     // We get a new list if we get a new session, or we add or delete a node 
     // from the cluster; or if we update a health score
-    bool changed_list = false;
     struct addr_score_s *addr_score[MAX_NODES + 1] = {NULL};
-
-    changed_list = new_session;
 
     // Is there anything in node_hash_table not in addr table,
     // e.g. a deleted addr
@@ -743,7 +740,6 @@ static void construct_resolve_slist(GHashTable *addr_table, bool new_session) {
         if (!exists) {
             // delete the node
             g_hash_table_iter_remove(&iter);
-            changed_list = true;
             log_print(LOG_DEBUG, SECTION_SESSION_DEFAULT, "%s: removed from hash table: %s", 
                     funcname, key);
         }
@@ -758,7 +754,6 @@ static void construct_resolve_slist(GHashTable *addr_table, bool new_session) {
         if (!exists) {
             // Add to node_hash_table
             set_health_status(logstr(key), value);
-            changed_list = true;
             log_print(LOG_DEBUG, SECTION_SESSION_DEFAULT, "%s: added to hash table: %s :: %s", 
                     funcname, key, value);
         }
@@ -775,15 +770,6 @@ static void construct_resolve_slist(GHashTable *addr_table, bool new_session) {
 
         // We need to sort on health score, but use the addr name.
         addr_score[addr_score_idx] = g_new(struct addr_score_s, 1);
-        // Take the opportunity to decrement the score by the amount of time which has passed since it last went bad.
-        // This will update the hashtable entry. It's a pointer, so update will stick
-        if (!new_session && healthstatus->score != HEALTHY) {
-            --healthstatus->score;
-            log_print(LOG_NOTICE, SECTION_SESSION_DEFAULT, 
-                    "%s: decrementing score; addr [%s], score [%d]",
-                    funcname, healthstatus->curladdr, healthstatus->score);
-            changed_list = true;
-        }
 
         // Save values into sortable array
         strncpy(addr_score[addr_score_idx]->addr, healthstatus->curladdr, IPSTR_SZ);
@@ -807,11 +793,9 @@ static void construct_resolve_slist(GHashTable *addr_table, bool new_session) {
 
     // addr_score_idx is the number of addresses we processed above
     for (int idx = 0; idx < addr_score_idx; idx++) {
-        if (changed_list) { // if we've potentially changed the list, let's see the new one
-            log_print(LOG_NOTICE, SECTION_SESSION_DEFAULT, 
-                    "%s: inserting into resolve_slist (%p): %s, score %d",
-                    funcname, node_status.resolve_slist, addr_score[idx]->addr, addr_score[idx]->score);
-        }
+        log_print(LOG_NOTICE, SECTION_SESSION_DEFAULT, 
+                "%s: inserting into resolve_slist (%p): %s, score %d",
+                funcname, node_status.resolve_slist, addr_score[idx]->addr, addr_score[idx]->score);
         node_status.resolve_slist = curl_slist_append(node_status.resolve_slist, addr_score[idx]->addr);
         g_free(addr_score[idx]);
     }
@@ -1087,7 +1071,7 @@ static bool slist_timed_out(void) {
     // timeout interval in seconds
     // If this interval has passed, we recreate the list. Within this interval,
     // we reuse the current list.
-    static const time_t resolve_slist_timeout = 120;
+    static const time_t resolve_slist_timeout = 600;
     // Keep a timer; at periodic intervals we reset the resolve_slist.
     // static so it persists between calls
     static __thread time_t prevtime = 0;
@@ -1104,51 +1088,11 @@ static bool slist_timed_out(void) {
 
     // Ready for the next invocation.
     prevtime = curtime;
+    log_print(LOG_DEBUG, SECTION_SESSION_DEFAULT, "slist_timed_out: timeout has elapsed on %s", nodeaddr);
     return true;
 }
 
-// Check that the new list of addresses matches the old list
-static bool slist_changed(GHashTable *addr_table) {
-    bool ret = false;
-    GHashTableIter iter;
-    gpointer key, value;
-
-    // If the two tables have different sizes, we know we have to recreate the slist
-    if (g_hash_table_size(addr_table) != g_hash_table_size(node_status.node_hash_table)) {
-        return true;
-    }
-
-    // Is there anything in node_hash_table not in addr table,
-    // e.g. a deleted addr
-    g_hash_table_iter_init (&iter, node_status.node_hash_table);
-    while (g_hash_table_iter_next (&iter, &key, &value)) {
-        bool exists = false;
-        // Is this address in addr_table?
-        exists = g_hash_table_lookup(addr_table, key);
-        if (!exists) {
-            ret = true;
-            break;
-        }
-    }
-    // If ret is already true, we already need a new session, so short-circuit.
-    if (ret == false) {
-        // Is there anything in addr_table not in node_hash_table
-        // e.g. an added addr
-        g_hash_table_iter_init (&iter, addr_table);
-        while (g_hash_table_iter_next (&iter, &key, &value)) {
-            bool exists = false;
-            // Is this address in addr_table?
-            exists = g_hash_table_lookup(node_status.node_hash_table, key);
-            if (!exists) {
-                ret = true;
-                break;
-            }
-        }
-    }
-    return ret;
-}
-
-static bool needs_new_session(GHashTable *addr_table, bool tmp_session) {
+static bool needs_new_session(bool tmp_session) {
     CURL *session;
     const char *funcname = "needs_new_session";
     bool new_session = false;
@@ -1177,15 +1121,10 @@ static bool needs_new_session(GHashTable *addr_table, bool tmp_session) {
         new_session = true;
     }
 
-    else if (slist_changed(addr_table)) {
-        log_print(LOG_INFO, SECTION_SESSION_DEFAULT, "%s: slist_changed", funcname);
-        new_session = true;
-    }
-
     // timeout
     else if (slist_timed_out()) {
         log_print(LOG_INFO, SECTION_SESSION_DEFAULT, "%s: slist_timed_out", funcname);
-        // Don't need new session on timeout
+        new_session = true;
     }
 
     // We're going to create a new session, so get rid of the old
@@ -1196,10 +1135,16 @@ static bool needs_new_session(GHashTable *addr_table, bool tmp_session) {
     return new_session;
 }
 
-static CURL *update_session(GHashTable *addr_table, bool tmp_session) {
+static CURL *update_session(bool tmp_session) {
     static const char *funcname = "update_session";
     CURL *session = NULL;
-    bool new_session = false;
+
+    // We only need a new addr_table if we need a new session, and if we call update_session,
+    // we need a new session
+    GHashTable *addr_table;
+    addr_table = create_new_addr_table();
+    // On getaddrinfo failure, NULL gets returned; pass it through
+    if (addr_table == NULL) return NULL;
 
     // create the hash table of node addresses for which we will keep health status
     // We do this when the thread is initialized. We want the hashtable to survive reinitialization of the handle,
@@ -1211,35 +1156,30 @@ static CURL *update_session(GHashTable *addr_table, bool tmp_session) {
 
     // if tmp_session, we need to get a new session for this request; otherwise see if we already have a session
     if (!tmp_session) {
-        // We might be just getting a new slist due to a timeout rather than a new session
         session = pthread_getspecific(session_tsd_key);
-        log_print(LOG_INFO, SECTION_SESSION_DEFAULT, "%s: session: %p", session);
-    }
-    if (session) {
-        // Unset curl DNS cache
-        // Might be able to do it by adding '-' before entries and passing list to CURL_RESOLVE
-        // then pass the new list right after. Needs trying.
-    }
-    else {
-        session = curl_easy_init();
-        if (!session) {
-            log_print(LOG_CRIT, SECTION_SESSION_DEFAULT, "%s: curl_easy_init returns NULL");
-            return NULL;
-        }
-        // We don't want a tmp session to muck with start time and resetting the main session
-        if (!tmp_session) {
-            // Keep track of start time so we can track how long sessions stay open
-            session_start_time = time(NULL);
-            pthread_setspecific(session_tsd_key, session);
-            log_print(LOG_INFO, SECTION_SESSION_DEFAULT, "%s: new session: %p", session);
-            update_session_count(true);
-            new_session = true;
+        if (session) {
+            log_print(LOG_CRIT, SECTION_SESSION_DEFAULT, "%s: Got unexpected already-existing session; deleting: %p", funcname, session);
+            session_cleanup(session);
         }
     }
 
-    log_print(LOG_DEBUG, SECTION_SESSION_DEFAULT, 
-            "%s: construct_resolve_slist: addr_table (%p)", funcname, addr_table);
-    construct_resolve_slist(addr_table, new_session);
+    session = curl_easy_init();
+    if (!session) {
+        log_print(LOG_CRIT, SECTION_SESSION_DEFAULT, "%s: curl_easy_init returns NULL", funcname);
+        return NULL;
+    }
+    // We don't want a tmp session to muck with start time and resetting the main session
+    if (!tmp_session) {
+        // Keep track of start time so we can track how long sessions stay open
+        session_start_time = time(NULL);
+        pthread_setspecific(session_tsd_key, session);
+        log_print(LOG_INFO, SECTION_SESSION_DEFAULT, "%s: new session: %p", funcname, session);
+        update_session_count(true);
+    }
+
+    log_print(LOG_DEBUG, SECTION_SESSION_DEFAULT, "%s: construct_resolve_slist: addr_table (%p)", funcname, addr_table);
+    construct_resolve_slist(addr_table);
+    g_hash_table_destroy(addr_table);
 
     return session;
 }
@@ -1248,13 +1188,8 @@ static CURL *get_session(bool tmp_session) {
     CURL *session;
     static const char * funcname = "get_session";
 
-    GHashTable *addr_table;
-    addr_table = create_new_addr_table();
-    // On getaddrinfo failure, NULL gets returned; pass it through
-    if (addr_table == NULL) return NULL;
-
-    if (needs_new_session(addr_table, tmp_session)) {
-        session = update_session(addr_table, tmp_session);
+    if (needs_new_session(tmp_session)) {
+        session = update_session(tmp_session);
         log_print(LOG_DEBUG, SECTION_SESSION_DEFAULT, "%s: update_session (%p)", funcname, session);
     }
     else {
@@ -1262,7 +1197,6 @@ static CURL *get_session(bool tmp_session) {
         log_print(LOG_DEBUG, SECTION_SESSION_DEFAULT, "%s: pthread session (%p)", funcname, session);
     }
 
-    g_hash_table_destroy(addr_table);
     return session;
 }
 
@@ -1286,6 +1220,8 @@ CURL *session_request_init(const char *path, const char *query_string, bool tmp_
         return NULL;
     }
 
+    // TODO(JB) Instead, can we just reset the ones that we might have changed?
+    // Will this allow us to not reset SSL, and will that help out memory use in libnss?
     curl_easy_reset(session);
 
     // Whether we created a new resolve_slist or not, we still need to
@@ -1319,7 +1255,6 @@ CURL *session_request_init(const char *path, const char *query_string, bool tmp_
     log_print(LOG_INFO, SECTION_SESSION_DEFAULT, "%s: Initialized request to URL: %s", funcname, full_url);
     free(full_url);
 
-    //curl_easy_setopt(session, CURLOPT_USERAGENT, "FuseDAV/" PACKAGE_VERSION);
     if (ca_certificate != NULL)
         curl_easy_setopt(session, CURLOPT_CAINFO, ca_certificate);
     if (client_certificate != NULL) {
@@ -1330,21 +1265,12 @@ CURL *session_request_init(const char *path, const char *query_string, bool tmp_
     curl_easy_setopt(session, CURLOPT_SSL_VERIFYPEER, 1);
     curl_easy_setopt(session, CURLOPT_FOLLOWLOCATION, 1);
     curl_easy_setopt(session, CURLOPT_CONNECTTIMEOUT_MS, 500);
+    // TODO(JB). One suggestion to make this work, move it closer to easy_perform
     curl_easy_setopt(session, CURLOPT_TIMEOUT, 60);
     //curl_easy_setopt(session, CURLOPT_LOW_SPEED_LIMIT, 1024);
     //curl_easy_setopt(session, CURLOPT_LOW_SPEED_TIME, 60);
     curl_easy_setopt(session, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
     curl_easy_setopt(session, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
-
-    // For curl configured for nss rather than openssl
-    // curl-config --configure ... '--without-ssl' '--with-nss'
-    // cipher list for nss at:
-    // https://git.fedorahosted.org/cgit/mod_nss.git/plain/docs/mod_nss.html
-    // Restrict to TLSv1.2
-    // Prefer gcm, but allow lesser cipher
-    // Don't set client ciphering; rely on server
-    // curl_easy_setopt(session, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
-    // curl_easy_setopt(session, CURLOPT_SSL_CIPHER_LIST, "ecdhe_rsa_aes_128_gcm_sha_256");
 
     return session;
 }

--- a/src/statcache.c
+++ b/src/statcache.c
@@ -785,7 +785,7 @@ void stat_cache_prune(stat_cache_t *cache) {
             }
             // We'll need to change path below, so we don't want it to be a part of iterkey.
             // Make a copy first.
-            strncpy(path, key, PATH_MAX);
+            g_strlcpy(path, key, PATH_MAX);
             log_print(LOG_DEBUG, SECTION_STATCACHE_PRUNE, "stat_cache_prune: ITERKEY: \'%s\' :: %s :: %s", iterkey, path, key);
             itervalue = (const struct stat_cache_value *) leveldb_iter_value(iter, &vlen);
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -150,6 +150,8 @@ void dump_stats(bool log, const char *cache_path) {
     }
 
     mallctl("prof.dump", NULL, NULL, NULL, 0);
+    mallctl("prof_leak", NULL, NULL, NULL, 0);
+    mallctl("prof.gdump", NULL, NULL, NULL, 0);
 
     snprintf(str, MAX_LINE_LEN, "Caught SIGUSR2. Printing status.");
     print_line(log, fd, LOG_NOTICE, SECTION_FUSEDAV_OUTPUT, str);

--- a/tests/continualtest.sh
+++ b/tests/continualtest.sh
@@ -21,7 +21,7 @@ EOF
 
 # do 64 rounds by default
 pid=0
-bid=0
+bid=""
 iters=64
 verbose=0
 # assuming we are using base fusedav; but allow for override
@@ -69,7 +69,7 @@ if [ $pid -eq 0 ]; then
     exit 1
 fi
     
-if [ $bid -eq 0 ]; then
+if [ $bid == "" ]; then
 	echo "Requires bid (7 chars only)"
     exit 1
 fi
@@ -83,6 +83,7 @@ do
     fusedavres=$(ps aux | grep mount.$fusedavdir | grep -v grep | grep $pid | awk '{printf "%5d %d\n", $2, $6}')
     nginxres=$(ps aux | grep nginx | grep -v grep | grep $bid | awk '{printf "%5d %d\n", $2, $6}')
     phpfmpres=$(ps aux | grep php-fpm | grep -v grep | grep $bid | awk '{printf "%5d %d\n", $2, $6}')
+    echo "$(date)"
     echo "$iter: fusedav before make: $fusedavres"
     echo "$iter: fusedav before make: $fusedavres" >> $pprof_out
     echo "$iter: nginx before make: $nginxres"

--- a/tests/saintmode-haproxy.sh
+++ b/tests/saintmode-haproxy.sh
@@ -135,14 +135,16 @@ do
 	do 
 		# echo $file
 		res=$(curl -s -H "Cache-Control: no-cache" -H "X-Bypass-Cache: 1" -I http://$uri/sites/default/$file | grep HTTP)
-		if [ $verbose -gt 0 ]; then
-			printf "SUCCEED: %s: %s : %s :: %s\n" "$0" "$uri" "$file" "$res"
-		fi
 
 		if [[ ! $res =~ '200' && ! $res =~ '301' && ! $res =~ '403' ]]; then
+			echo "curl -s -H 'Cache-Control: no-cache' -H 'X-Bypass-Cache: 1' -I http://$uri/sites/default/$file"
 			printf "ERROR: %s: %s :: %s\n" "$0" "$file" "$res"
 			fail=$((fail + 1))
 		else
+			if [ $verbose -gt 0 ]; then
+				echo "curl -s -H 'Cache-Control: no-cache' -H 'X-Bypass-Cache: 1' -I http://$uri/sites/default/$file"
+				printf "SUCCEED: %s: %s : %s :: %s\n" "$0" "$uri" "$file" "$res"
+			fi
 			pass=$((pass + 1))
 		fi
 		if [ $verbose -gt 0 ]; then


### PR DESCRIPTION
We used to call getaddrinfo only on error or after timeout; then a couple of months back we started calling it on every request. Our call had a long-standing memory leak which calling it on every request exacerbated, but after fixing it we didn't see a drop in memory issues. This change again calls getaddrinfo on error or timeout, not on every request, but this hasn't resolved memory issues.
This also makes resolve_slist timeout 10 minutes, up from 2, and also forces deletion of the old session and creation of a new one, to improve randomization. This makes checking for changed nodes in a cluster less urgent, so we no longer do it explicitly. If a node is added or deleted, it might not be detected until the next timeout in up to 10 minutes.