### PR TITLE
Use pkill to detect and kill previous fusedav process still hanging on

### DIFF
--- a/scripts/exec_wrapper/mount.fusedav_chan
+++ b/scripts/exec_wrapper/mount.fusedav_chan
@@ -12,16 +12,8 @@ if [ -z "$channel" ]; then
   exit 1
 fi
 
-
-# we don't want to grep a channel here, because we want to delete processes
-# that might be part of a transition from one channel to another
-res=$(ps aux | grep $2 | grep mount.fusedav | grep -v grep)
-if [ "$res" != "" ];  then
-
-        IFS=' ' read -a resarr <<< ${res}
-        pid=${resarr[1]}
-        kill $pid
-fi
+# If there is a current process still running, pkill it
+pkill -f "/opt/pantheon/fusedav.*$2"
 
 # run fusedav with given options
 /opt/pantheon/$channel/$channel "$@"


### PR DESCRIPTION
The previous version of the mount file was killing itself, since the name of the script executing matched the grep pattern (/bin/sh /sbin/mount.fusedav-...). The previous version in mount.fusedav avoided this by refering to the binary itself in the grep pattern (fusedavbin). This version does the same (/opt/pantheon/fusedav.*<bid>). It also uses pkill as a more straightforward method than the ps aux and if clause of mount.fusedav. It maight also have a further benefit. We initially added the script with a check for previously running not yet dead fusedav processes in order to avoid the infinite remount loops that on rare occasions were happening. It seems to have improved that situation without completely fixing it. One suspicion is that there are more than a single still-running fusedav process, and the previous method was only killing one. I think pkill will detect and kill all of them.