### PR TITLE
Stage to master/release

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,4 +32,4 @@ deployment:
     commands:
       - gem install package_cloud
       - git push --tags
-      - bash scripts/pkgcloud_push.sh internal
+      - bash scripts/push_packagecloud.sh internal


### PR DESCRIPTION
The underlying fusedav binary has changed. Compile options were changed, mostly threaded resolver. This should diminish the number of segv we have been seeing.