### PR TITLE
Maintenance changes

### DIFF
--- a/src/filecache.c
+++ b/src/filecache.c
@@ -724,8 +724,8 @@ static void get_fresh_fd(filecache_t *cache,
             unsigned long exceeded_count = 0;
             log_print(LOG_WARNING, SECTION_FILECACHE_OPEN, "put_fresh_fd: small (%lu) GET for %s exceeded time allotment %lu with %lu",
                 st.st_size, path, small_time_allotment, elapsed_time);
-            aggregate_log_print_server(LOG_INFO, SECTION_ENHANCED, "put_fresh_fd", NULL, "exceeded-time-short-GET-count",
-                &exceeded_count, 1, "exceeded-time-short-GET-latency", &elapsed_time, 0);
+            aggregate_log_print_server(LOG_INFO, SECTION_ENHANCED, "put_fresh_fd", NULL, "exceeded-time-small-GET-count",
+                &exceeded_count, 1, "exceeded-time-small-GET-latency", &elapsed_time, 0);
         }
     }
     else if (response_code == 404) {

--- a/src/fusedav.c
+++ b/src/fusedav.c
@@ -120,6 +120,8 @@ static int simple_propfind_with_redirect(
 
     clock_gettime(CLOCK_MONOTONIC, &start_time);
     ret = simple_propfind(path, depth, last_updated, result_callback, userdata, &subgerr);
+    aggregate_log_print_server(LOG_INFO, SECTION_ENHANCED, "simple_propfind_with_redirect", &time, "propfind-count", &count, 1,
+        "propfind-latency", &latency, elapsed_time);
     clock_gettime(CLOCK_MONOTONIC, &now);
     elapsed_time = ((now.tv_sec - start_time.tv_sec) * 1000) + ((now.tv_nsec - start_time.tv_nsec) / (1000 * 1000));
     /* The aggregate_log_print_server routine is expecting a cumulative count and latency, but by
@@ -137,8 +139,6 @@ static int simple_propfind_with_redirect(
         return ret;
     }
 
-    aggregate_log_print_server(LOG_INFO, SECTION_ENHANCED, "simple_propfind_with_redirect", &time, "propfind-count", &count, 1,
-        "propfind-latency", &latency, elapsed_time);
     log_print(LOG_DEBUG, SECTION_FUSEDAV_STAT, "simple_propfind_with_redirect: Done with (%s) PROPFIND.", last_updated > 0 ? "progressive" : "complete");
 
     return ret;

--- a/src/session.c
+++ b/src/session.c
@@ -300,16 +300,16 @@ static unsigned int health_status_all_nodes(void) {
 }
 
 static void increment_node_success(char *addr) {
-    struct health_status_s *health_status = get_health_status(addr);
-    if (!health_status) {
-        log_print(LOG_CRIT, SECTION_SESSION_DEFAULT, "increment_node_success: health_status null for %s", addr);
+    struct health_status_s *healthstatus = get_health_status(addr);
+    if (!healthstatus) {
+        log_print(LOG_CRIT, SECTION_SESSION_DEFAULT, "increment_node_success: healthstatus null for %s", addr);
         return;
     }
-    if (health_status->score > HEALTHY) {
-        --health_status->score;
-        health_status->timestamp = time(NULL); // Reset since we just used it
+    if (healthstatus->score > HEALTHY) {
+        --healthstatus->score;
+        healthstatus->timestamp = time(NULL); // Reset since we just used it
         log_print(LOG_NOTICE, SECTION_SESSION_DEFAULT, "increment_node_success: %s addr score set to %u",
-            addr, health_status->score);
+            addr, healthstatus->score);
     }
 }
 
@@ -687,30 +687,30 @@ static int compare_node_score(const void *x, const void *y) {
 static bool set_health_status(char *addr, char *curladdr) {
     static const char *funcname = "set_health_status";
     bool added_entry = false;
-    struct health_status_s *health_status = NULL;
-    health_status = g_hash_table_lookup(node_status.node_hash_table, addr);
-    if (health_status) {
-        if (curladdr && health_status->curladdr[0] == '\0') {
-            strncpy(health_status->curladdr, curladdr, LOGSTRSZ);
+    struct health_status_s *healthstatus = NULL;
+    healthstatus = g_hash_table_lookup(node_status.node_hash_table, addr);
+    if (healthstatus) {
+        if (curladdr && healthstatus->curladdr[0] == '\0') {
+            strncpy(healthstatus->curladdr, curladdr, LOGSTRSZ);
             log_print(LOG_NOTICE, SECTION_SESSION_DEFAULT, 
                     "%s: existing entry didn't have curladdr %s", funcname, addr);
         }
         log_print(LOG_DEBUG, SECTION_SESSION_DEFAULT, "%s: reusing entry for %s", funcname, addr);
-        health_status->current = true;
+        healthstatus->current = true;
     }
     else {
-        health_status = g_new(struct health_status_s, 1);
-        health_status->score = HEALTHY;
-        health_status->timestamp = 0;
-        health_status->current = true;
+        healthstatus = g_new(struct health_status_s, 1);
+        healthstatus->score = HEALTHY;
+        healthstatus->timestamp = 0;
+        healthstatus->current = true;
         if (curladdr) {
-            strncpy(health_status->curladdr, curladdr, LOGSTRSZ);
+            strncpy(healthstatus->curladdr, curladdr, LOGSTRSZ);
         }
         else {
             log_print(LOG_NOTICE, SECTION_SESSION_DEFAULT, 
                     "%s: new entry doesn't have curladdr %s", addr);
         }
-        g_hash_table_replace(node_status.node_hash_table, g_strdup(addr), health_status);
+        g_hash_table_replace(node_status.node_hash_table, g_strdup(addr), healthstatus);
         log_print(LOG_INFO, SECTION_SESSION_DEFAULT, 
                 "%s: creating new entry for %s // %s", funcname, addr, curladdr);
         added_entry = true;
@@ -1020,28 +1020,28 @@ static void delete_session(CURL *session, bool tmp_session) {
 
 static void increment_node_failure(char *addr, const CURLcode res, const long response_code, const long elapsed_time) {
     const char * funcname = "increment_node_failure";
-    struct health_status_s *health_status = get_health_status(addr);
-    if (!health_status) {
-        log_print(LOG_CRIT, SECTION_SESSION_DEFAULT, "%s: health_status null for %s", funcname, addr);
+    struct health_status_s *healthstatus = get_health_status(addr);
+    if (!healthstatus) {
+        log_print(LOG_CRIT, SECTION_SESSION_DEFAULT, "%s: healthstatus null for %s", funcname, addr);
         return;
     }
     // Currently treat !CURLE_OK and response_code > 500 the same, but leave in structure if we want to treat them differently.
     if (res != CURLE_OK) {
-        health_status->score = UNHEALTHY;
+        healthstatus->score = UNHEALTHY;
         log_print(LOG_ERR, SECTION_SESSION_DEFAULT, "%s: !CURLE_OK: %s addr score set to %d",
-            funcname, addr, health_status->score);
+            funcname, addr, healthstatus->score);
     }
     else if (response_code >= 500) {
-        health_status->score = UNHEALTHY;
+        healthstatus->score = UNHEALTHY;
         log_print(LOG_ERR, SECTION_SESSION_DEFAULT, "%s: response_code %lu: %s addr score set to %d",
-            funcname, response_code, addr, health_status->score);
+            funcname, response_code, addr, healthstatus->score);
     }
     else if (elapsed_time > time_limit) {
-        health_status->score = UNHEALTHY;
+        healthstatus->score = UNHEALTHY;
         log_print(LOG_ERR, SECTION_SESSION_DEFAULT, "%s: slow_request %lu: %s addr score set to %d",
-            funcname, elapsed_time, addr, health_status->score);
+            funcname, elapsed_time, addr, healthstatus->score);
     }
-    health_status->timestamp = time(NULL); // Most recent failure. We don't currently use this value, but it might be interesting
+    healthstatus->timestamp = time(NULL); // Most recent failure. We don't currently use this value, but it might be interesting
 }
 
 void process_status(const char *fcn_name, CURL *session, const CURLcode res, 


### PR DESCRIPTION
1) fusedav was only counting successful propfinds and the tally was different from valhalla's. Move the count up so even failed attempts get counted
2) We reference 'small' requests but the wording in fusedav was 'short' so they weren't appearing on graphs. Fix.
3) Standardize variable name on 'healthstatus' instead of sometimes 'health_status'. Also makes it easier to distinguish from type name.