### PR TITLE
Altering timeouts.

### DIFF
--- a/src/props.c
+++ b/src/props.c
@@ -361,6 +361,9 @@ int simple_propfind(const char *path, size_t depth, time_t last_updated, props_r
         XML_SetCharacterDataHandler(parser, characterDataHandler);
         curl_easy_setopt(session, CURLOPT_WRITEDATA, (void *) parser);
         curl_easy_setopt(session, CURLOPT_WRITEFUNCTION, write_parsing_callback);
+        curl_easy_setopt(session, CURLOPT_TIMEOUT, 0);
+        curl_easy_setopt(session, CURLOPT_LOW_SPEED_LIMIT, 1024);
+        curl_easy_setopt(session, CURLOPT_LOW_SPEED_TIME, 240);
 
         // Add the Depth header and PROPFIND verb.
         curl_easy_setopt(session, CURLOPT_CUSTOMREQUEST, "PROPFIND");

--- a/src/session.c
+++ b/src/session.c
@@ -1245,7 +1245,7 @@ CURL *session_request_init(const char *path, const char *query_string, bool tmp_
     curl_easy_setopt(session, CURLOPT_SSL_VERIFYPEER, 1);
     curl_easy_setopt(session, CURLOPT_FOLLOWLOCATION, 1);
     curl_easy_setopt(session, CURLOPT_CONNECTTIMEOUT_MS, 1200);
-    curl_easy_setopt(session, CURLOPT_TIMEOUT, 60);
+    curl_easy_setopt(session, CURLOPT_TIMEOUT, 20);
     curl_easy_setopt(session, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
     curl_easy_setopt(session, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
 


### PR DESCRIPTION
Our 60s global timeout is probably too long, yet it's too short for some prop-finds.

Proposing a shorter default timeout and prop-find specifically using a low-speed timeout instead.

Changed:
Global Timeout from 60s to 20s
Prop-Find Timeout from fixed to low-speed (SWAGing at 16KB/s over 120s).
