### PR TITLE
Propfind fix

### DIFF
--- a/tests/rename.c
+++ b/tests/rename.c
@@ -1,0 +1,137 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <time.h>
+#include <stdlib.h>
+#include <dirent.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <getopt.h>
+
+#define PATH_MAX 4096
+static const int write_size = 1024;
+
+static bool verbose = false;
+
+static void usage() {
+    printf("One arg, -v for verbose\n");
+    exit(0);
+}
+
+static void v_printf(const char *fmt, ...) {
+    if (verbose) {
+        va_list ap;
+        va_start(ap, fmt);
+        vfprintf(stdout, fmt, ap);
+        va_end(ap);
+    }
+}
+
+static char randomchar() {
+    int randval;
+
+    randval = rand() % 52;
+    randval += 'A';
+    return (char)randval;
+}
+
+static int writeread(char *origfilename, char *newfilename) {
+    char wbuf[write_size];
+    int fd;
+
+    for (int idx = 0; idx < write_size; idx++) {
+        wbuf[idx] = randomchar();
+    }
+
+    v_printf("write: ");
+    int bytes_written;
+    fd = open(origfilename, O_RDWR | O_CREAT, 0640);
+    if (fd < 0) {
+        v_printf("OPEN ERROR: open failed on %s : %d %s\n", origfilename, errno, strerror(errno));
+        return -1;
+    }
+    bytes_written = write(fd, wbuf, write_size);
+    if (bytes_written != write_size) {
+        v_printf("WRITE ERROR: bytes_written = %d, write_size = %d\n", bytes_written, write_size);
+        return -3;
+    }
+    else {
+        v_printf("Write Success: %s\n", origfilename);
+    }
+
+    sleep(10);
+
+    if (rename(origfilename, newfilename) != 0) {
+        v_printf("RENAME ERROR: old: %s; new: %s; errno: %d; err: %s\n", origfilename, newfilename, errno, strerror(errno));
+        return -4;
+    }
+
+    close(fd);
+
+    return 0;
+}
+
+int main(int argc, char *argv[]) {
+    char dirname[] = "rename";
+    char origfilename[] = "origfilename";
+    char newfilename[] = "newfilename";
+    char pathtofile[] = "rename/newfilename";
+    int ret;
+    int opt;
+    bool fail = false;
+
+    while ((opt = getopt (argc, argv, "uvhf:")) != -1) {
+        switch (opt)
+        {
+            case 'v':
+                verbose = true;
+                break;
+            case 'h':
+            case '?':
+            default:
+                usage ();
+        }
+    }
+
+    if (unlink(pathtofile) < 0) {
+        if (errno != ENOENT) {
+            printf("FAIL: Couldn't delete file %s. errno: %d; err: %s\n", pathtofile, errno, strerror(errno));
+            exit(1);
+        }
+    }
+
+    if (remove(dirname) < 0) {
+        if (errno != ENOENT) {
+            printf("FAIL: Couldn't delete directory. errno: %d; err: %s\n", errno, strerror(errno));
+            exit(1);
+        }
+    }
+
+    ret = mkdir(dirname, 0755);
+    if (ret < 0) {
+        printf("FAIL: Couldn't make directory %s. Exiting\n", dirname);
+        exit(1);
+    }
+    ret = chdir(dirname);
+    if (ret < 0) {
+        printf("FAIL: Couldn't change to directory %s. Exiting\n", dirname);
+        exit(1);
+    }
+
+    ret = writeread(origfilename, newfilename);
+    if (ret < 0) {
+        printf("writeread failed. exitcode: %d\n", ret);
+        fail = true;
+    }
+
+    if (fail) {
+        printf("FAIL:\n");
+    }
+    else {
+        printf("PASS:\n");
+    }
+}


### PR DESCRIPTION
The problem is: sometimes fusedav thinks a file exists when the fileserver doesn't, and this leads to error messages like 'file expected to exist returns 404'.

A. Initially, I thought there was an issue with dav_rename. We explicitly allow a 'rename' aka 'move' to succeed if it succeeds locally but fails on the fileserver. I thought that dav_rename did not do a dav_release stage, which could cause this discrepancy, but turns out it does the release and syncs local and valhalla. This makes the problem less serious than I thought it might be.
B. When utilities like image manipulators are run on an environment with multiple bindings, where the utility creates, renames, and deletes files as it does its manipulation, two bindings can get into a race condition on the same file or directory. I believe that the effort required to defend against this will cause way more pain than these temporary inconsistencies. Also, the inconsistencies straighten themselves out soon enough. The initial requests which get caught up in these inconsistencies will return incorrect results, but fusedav cleans up, and subsequent requests should succeed as expected.
C. Race conditions on files result in 'file expected to exist returns 404'. In this case, that initial request will be incorrect, but subsequent ones should succeed as expected. Race conditions on directories I believe with these changes in this PR will correct themselves and return correct results even on the initial request which caught the race condition inconsistency.

As noted, this PR does not correct for race conditions on files and the dreaded 'file expected to exist returns 404.' I don't think there is a reasonable/feasible solution to that problem.