### PR TITLE
Add stats for seconds since last update for stat cache value get and …

### DIFF
--- a/src/fusedav-statsd.c
+++ b/src/fusedav-statsd.c
@@ -332,20 +332,20 @@ int stats_timer_local(const char *statname, const int value) {
 }
 
 // Not really a histogram, but keeps separate stats for each value
-int stats_histo(const int value, const int max, const char *descriptor) {
+int stats_histo(const char *statname, const int value, const int max) {
     char *value_str = NULL;
     char *attempts_str = NULL;
     int ret;
 
     if (value <= max) {
-        asprintf(&value_str, "%d_%s", value, descriptor);
+        asprintf(&value_str, "%d_%s", value, statname);
     } else {
-        asprintf(&value_str, "gt_%d_%s", max, descriptor);
+        asprintf(&value_str, "gt_%d_%s", max, statname);
     }
     // Is this the first, second, or third failure for this request?
     stats_counter(value_str, 1);
     free(value_str);
-    asprintf(&attempts_str, "%s_attempts", descriptor);
+    asprintf(&attempts_str, "%s_attempts", statname);
     ret = stats_counter(attempts_str, 1);
     free(attempts_str);
     return ret;

--- a/src/fusedav-statsd.c
+++ b/src/fusedav-statsd.c
@@ -32,6 +32,7 @@
 #include "log_sections.h"
 #include "fusedav-statsd.h"
 #include "session.h"
+#include "util.h"
 
 // e.g. fusedav.valhallayolo1b.server-104_130_221_144.exceeded-time-small-GET-latency (82 characters)
 #define STATS_MSG_LEN 128
@@ -328,6 +329,26 @@ int stats_timer_cluster(const char *statname, const int value) {
 
 int stats_timer_local(const char *statname, const int value) {
     return stats_timer_common(statname, value, NULL, NULL);
+}
+
+// Not really a histogram, but keeps separate stats for each value
+int stats_histo(const int value, const int max, const char *descriptor) {
+    char *value_str = NULL;
+    char *attempts_str = NULL;
+    int ret;
+
+    if (value <= max) {
+        asprintf(&value_str, "%d_%s", value, descriptor);
+    } else {
+        asprintf(&value_str, "gt_%d_%s", max, descriptor);
+    }
+    // Is this the first, second, or third failure for this request?
+    stats_counter(value_str, 1);
+    free(value_str);
+    asprintf(&attempts_str, "%s_attempts", descriptor);
+    ret = stats_counter(attempts_str, 1);
+    free(attempts_str);
+    return ret;
 }
 
 /* For reference: 

--- a/src/fusedav-statsd.h
+++ b/src/fusedav-statsd.h
@@ -31,5 +31,6 @@ int stats_gauge_local(const char *statname, const int value);
 int stats_timer(const char *statname, const int value);
 int stats_timer_cluster(const char *statname, const int value);
 int stats_timer_local(const char *statname, const int value);
+int stats_histo(const int value, const int max, const char *descriptor);
 
 #endif

--- a/src/fusedav-statsd.h
+++ b/src/fusedav-statsd.h
@@ -31,6 +31,6 @@ int stats_gauge_local(const char *statname, const int value);
 int stats_timer(const char *statname, const int value);
 int stats_timer_cluster(const char *statname, const int value);
 int stats_timer_local(const char *statname, const int value);
-int stats_histo(const int value, const int max, const char *descriptor);
+int stats_histo(const char *statname, const int value, const int max);
 
 #endif

--- a/src/fusedav.c
+++ b/src/fusedav.c
@@ -757,7 +757,7 @@ static void get_stat(const char *path, struct stat *stbuf, GError **gerr) {
     // If the parent directory is out of date, update it.
     time_since = time(NULL) - STAT_CACHE_NEGATIVE_TTL;
     // Keep stats for each second 0-6, then bucket everything over 6
-    stats_histo(time_since, 6, "sc_neg_ttl");
+    stats_histo("profind_ttl", time_since, 6);
     if (parent_children_update_ts < time_since) {
         GError *subgerr = NULL;
 

--- a/src/statcache.c
+++ b/src/statcache.c
@@ -34,6 +34,7 @@
 #include "bloom-filter.h"
 #include "util.h"
 #include "stats.h"
+#include "fusedav-statsd.h"
 
 #define CACHE_TIMEOUT 3
 
@@ -247,19 +248,26 @@ struct stat_cache_value *stat_cache_value_get(stat_cache_t *cache, const char *p
 
     if (!skip_freshness_check) {
         time_t current_time = time(NULL);
+        time_t time_since;
 
         // First, check against the stat item itself.
         //log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, "Current time: %lu", current_time);
-        if (current_time - value->updated > CACHE_TIMEOUT) {
+        // How long has it been since the item was updated
+        time_since = current_time - value->updated;
+
+        // Keep stats for each second 0-6, then bucket everything over 6
+        stats_histo(time_since, 6, "sc_value_get");
+        if (time_since > CACHE_TIMEOUT) {
             char *directory;
             time_t directory_updated;
 
-            log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, "stat_cache_value_get: Stat entry %s is %lu seconds old.", path, current_time - value->updated);
+            log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, "stat_cache_value_get: Stat entry %s is %lu seconds old.", 
+                    path, time_since);
 
             // If that's too old, check the last update of the directory.
             directory = path_parent(path);
             if (directory == NULL) {
-                log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, "stat_cache_value_get: Stat entry %s is %lu seconds old.", path, current_time - value->updated);
+                log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, "stat_cache_value_get: Stat entry for directory %s is NULL.", path);
                 return NULL;
             }
 
@@ -268,10 +276,15 @@ struct stat_cache_value *stat_cache_value_get(stat_cache_t *cache, const char *p
                 g_propagate_prefixed_error(gerr, tmpgerr, "stat_cache_value_get: ");
                 return NULL;
             }
-            log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, "stat_cache_value_get: Directory contents for %s are %lu seconds old.", directory, (current_time - directory_updated));
+            time_since = current_time - directory_updated;
+            // Keep stats for each second 0-6, then bucket everything over 6
+            stats_histo(time_since, 6, "sc_dir_update");
+            log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, "stat_cache_value_get: Directory contents for %s are %lu seconds old.", 
+                    directory, time_since);
             free(directory);
-            if (current_time - directory_updated > CACHE_TIMEOUT) {
-                log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, "stat_cache_value_get: %s is too old.", path);
+            if (time_since > CACHE_TIMEOUT) {
+                log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, "stat_cache_value_get: %s is too old (%lu seconds).", 
+                        path, time_since);
                 free(value);
                 return NULL;
             }


### PR DESCRIPTION
…get_stat directory update.
Get stats to know the distribution of propfind attempts that are satisfied locally vs. going to server, so we can make better decisions on how to adjust propfinds. We want to reduce or eliminate the STAT_CACHE_NEGATIVE_TTL but not overwhelm the server with more propfind requests.

Some background. If we hit in the stat cache on an item that has been updated in the previous CACHE_TIMEOUT seconds (3), we satisfy the request locally and do not make a request of the server. If not, then if the directory has been updated in the most recent STAT_CACHE_NEGATIVE_TTL seconds (2), we do not make the request to the server but satisfy locally. Unfortunately, due to the interplay between these two timeout values, whenever we serve locally in the second case, it's a 404. We would like to diminish the time, perhaps to zero, between when one binding creates a new file and the other bindings find out about its existence.

We saw this issue on recreation of aggregated css files, but is a more general problem.