### PR TITLE
Change break to continue in stathe_prune to prevent iter issues

### DIFF
--- a/src/statcache.c
+++ b/src/statcache.c
@@ -921,7 +921,7 @@ void stat_cache_prune(stat_cache_t *cache, bool first) {
                 // Other stat cache entries have paths in them and pass the key2path test, e.g.
                 // fc:/path and updated_children:/path
                 if (!strncmp(iterkey, "data_version", strlen("data_version"))) {
-                    break;
+                    continue;
                 }
                 else {
                     log_print(LOG_NOTICE, SECTION_STATCACHE_PRUNE, "stat_cache_prune: ignoring malformed iterkey: %s", iterkey);


### PR DESCRIPTION
I had thought that we would have already traversed the regular entries since they contain a number as the first character and should be alphabetically earlier, but the break seems to cause the iter to start again skipping an entry, and when that entry doesn't make it to the bloom filter, all children are deleted from the statcache. So change the 'break' to a 'continue'.