### PR TITLE
Stage to master: intermediate fusedav version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ config.h.in
 /tests/forensic-haven-test
 /tests/openunlinkclose
 /tests/trunc
+/tests/rename
 tests/perfanalysis-read
 tests/perfanalysis-write
 tests/one-open-many-writes

--- a/src/fusedav.c
+++ b/src/fusedav.c
@@ -2009,7 +2009,7 @@ static void *cache_cleanup(void *ptr) {
         if (gerr) {
             processed_gerror("cache_cleanup: ", config->cache_path, &gerr);
         }
-        stat_cache_prune(config->cache);
+        stat_cache_prune(config->cache, first);
         if (!first) {
             binding_busyness_stats();
         }

--- a/src/statcache.c
+++ b/src/statcache.c
@@ -921,7 +921,7 @@ void stat_cache_prune(stat_cache_t *cache, bool first) {
                 // Other stat cache entries have paths in them and pass the key2path test, e.g.
                 // fc:/path and updated_children:/path
                 if (!strncmp(iterkey, "data_version", strlen("data_version"))) {
-                    break;
+                    continue;
                 }
                 else {
                     log_print(LOG_NOTICE, SECTION_STATCACHE_PRUNE, "stat_cache_prune: ignoring malformed iterkey: %s", iterkey);

--- a/src/statcache.h
+++ b/src/statcache.h
@@ -82,6 +82,6 @@ void stat_cache_delete_older(stat_cache_t *cache, const char *key_prefix, unsign
 void stat_cache_walk(void);
 int stat_cache_enumerate(stat_cache_t *cache, const char *key_prefix, void (*f) (const char *path_prefix, const char *filename, void *user), void *user, bool force);
 bool stat_cache_dir_has_child(stat_cache_t *cache, const char *path);
-void stat_cache_prune(stat_cache_t *cache);
+void stat_cache_prune(stat_cache_t *cache, bool first);
 
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -115,6 +115,8 @@ void *inject_error_mechanism(void *ptr);
 #define statcache_error_readchildrenldb 74
 #define statcache_error_setldb 75
 #define statcache_error_deleteldb 76
+#define statcache_error_data_version_get 77
+#define statcache_error_data_version_set 78
 
 #define config_error_parse 80
 #define config_error_sessioninit 81


### PR DESCRIPTION
This version removed negative entries on binding restart, when it goes through the cache pruning exercise. If a site is on the next version of fusedav, and creates negative entries, and then has to be reverted to the previous version, we need a way to keep those negative entries from confusing fusedav and the kernel.
This version also introduces stat cache data versioning. As the future unrolls, if we change the structure of data stored in the stat cache, we can use the data version marker to know what to expect and what to ask for. Stat caches existing when this version rolls out and get restarted to use it will be tagged as data version 1; stat caches which start fresh (after invalidate or migrations, or new bindings) will get data version 2.