### PR TITLE
Problem: nodaemon config option is not parsed

### DIFF
--- a/src/fusedav_config.c
+++ b/src/fusedav_config.c
@@ -188,7 +188,7 @@ static void parse_configs(struct fusedav_config *config, GError **gerr) {
         keytuple(fusedav, progressive_propfind, BOOL),
         keytuple(fusedav, refresh_dir_for_file_stat, BOOL),
         keytuple(fusedav, grace, BOOL),
-	keytuple(fusedav, nodaemon, BOOL),
+        keytuple(fusedav, nodaemon, BOOL),
         keytuple(fusedav, cache_uri, STRING),
         keytuple(fusedav, ca_certificate, STRING),
         keytuple(fusedav, client_certificate, STRING),

--- a/src/fusedav_config.c
+++ b/src/fusedav_config.c
@@ -188,6 +188,7 @@ static void parse_configs(struct fusedav_config *config, GError **gerr) {
         keytuple(fusedav, progressive_propfind, BOOL),
         keytuple(fusedav, refresh_dir_for_file_stat, BOOL),
         keytuple(fusedav, grace, BOOL),
+	keytuple(fusedav, nodaemon, BOOL),
         keytuple(fusedav, cache_uri, STRING),
         keytuple(fusedav, ca_certificate, STRING),
         keytuple(fusedav, client_certificate, STRING),


### PR DESCRIPTION
Solution: Make the config struct aware of this key

We need nodaemon to work for abstract OS