### PR TITLE
If using shortnames for base, use domain as cluster name as well

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -200,13 +200,14 @@ int session_config_init(char *base, char *ca_cert, char *client_cert, bool grace
     filesystem_domain = strndup(uri.hostText.first, uri.hostText.afterLast - uri.hostText.first);
     filesystem_port = strndup(uri.portText.first, uri.portText.afterLast - uri.portText.first);
     firstdot = strchr(uri.hostText.first, '.');
+    // If we change the format of the base, this logic might no longer find the cluster
     if (firstdot) {
         filesystem_cluster = strndup(uri.hostText.first, firstdot - uri.hostText.first);
     }
     else {
-        /* Failure */
-        log_print(LOG_CRIT, SECTION_SESSION_DEFAULT, "session_config_init: error on uriParse finding cluster name: %s", base);
-        asprintf(&filesystem_cluster, "unknown");
+        // If using shortnames, make the cluster the same as the domain.
+        log_print(LOG_NOTICE, SECTION_SESSION_DEFAULT, "session_config_init: no cluster name in base: %s", base);
+        filesystem_cluster = g_strdup(filesystem_domain);
     }
     uriFreeUriMembersA(&uri);
 


### PR DESCRIPTION
If we're using shortnames, make the cluster the same as the domain (for stats).
If we change the format of the base name (the What line in the mount file) but not use shortnames, fusedav might not properly find the cluster name, and the stats might go awry.
If we change from the current base name to shortnames for production clusters, stats will be off for awhile since they use the cluster name, which just got changed.