### PR TITLE
Content length mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ config.h.in
 tests/perfanalysis-read
 tests/perfanalysis-write
 tests/one-open-many-writes
+tests/stat-fstat
+tests/stat-fstat-unlink
+tests/stat-stat
+tests/stat-stat-unlink
+tests/stat-vs-fstat
 /src/*.plist
 _trial_temp*
 

--- a/src/filecache.c
+++ b/src/filecache.c
@@ -627,7 +627,10 @@ static void get_fresh_fd(filecache_t *cache,
         // deleted once no more file descriptors reference it.
         if (unlink_old) {
             unlink(old_filename);
-            log_print(LOG_DEBUG, SECTION_FILECACHE_OPEN, "%s: 200: unlink old filename %s", funcname, old_filename);
+            log_print(LOG_NOTICE, SECTION_FILECACHE_OPEN, "%s: 200: unlink old filename %s", funcname, old_filename);
+            // The file has changed, the stat values might have too. Delete the entry. It will have to
+            // be reconstituted on the next access
+            stat_cache_delete(cache, path, NULL);
         }
 
         if (fstat(sdata->fd, &st)) {

--- a/src/filecache.c
+++ b/src/filecache.c
@@ -44,9 +44,6 @@
 #define REFRESH_INTERVAL 3
 #define CACHE_FILE_ENTROPY 20
 
-// Remove filecache files older than 8 days
-#define AGE_OUT_THRESHOLD 691200
-
 // Keeping track of file sizes processed
 #define XLG 100 * 1024 * 1024
 #define LG 10 * 1024 * 1024
@@ -1694,7 +1691,7 @@ static const char *key2path(const char *key) {
     return NULL;
 }
 
-void filecache_cleanup(filecache_t *cache, const char *cache_path, bool first, GError **gerr) {
+bool filecache_cleanup(filecache_t *cache, const char *cache_path, bool first, GError **gerr) {
     leveldb_iterator_t *iter = NULL;
     leveldb_readoptions_t *options;
     GError *tmpgerr = NULL;
@@ -1709,6 +1706,14 @@ void filecache_cleanup(filecache_t *cache, const char *cache_path, bool first, G
     int unlinked_files = 0;
     int issues = 0;
     int pruned_files = 0;
+    bool done = false;
+    int total_size = 0;
+    time_t earliest = 0;
+    // By default, keep any file younger than 8 days old
+    time_t age_out = 691200
+    // Take evasive action if there are more than 128GB in the file cache
+    const int max_cache_size = 128 * 1024 * 1024 * 1024;
+    bool reduce_interval = false;
 
     BUMP(filecache_cleanup);
 
@@ -1722,63 +1727,90 @@ void filecache_cleanup(filecache_t *cache, const char *cache_path, bool first, G
 
     starttime = time(NULL);
 
-    while (leveldb_iter_valid(iter)) {
-        const struct filecache_pdata *pdata;
-        const char *iterkey;
-        const char *path;
-        // We need the key to get the path in case we need to remove the entry from the filecache
-        iterkey = leveldb_iter_key(iter, &klen);
-        path = key2path(iterkey);
-        // if path is null, we've gone past the filecache entries
-        if (path == NULL) break;
-        pdata = (const struct filecache_pdata *)leveldb_iter_value(iter, &klen);
-        log_print(LOG_DEBUG, SECTION_FILECACHE_CLEAN, "filecache_cleanup: Visiting %s :: %s", path, pdata ? pdata->filename : "no pdata");
-        if (pdata) {
-            ++cached_files;
-            // We delete the entry, making pdata invalid, before we might need the filename to unlink,
-            // so store it in fname
-            strncpy(fname, pdata->filename, PATH_MAX);
+    while (!done) {
+        total_size = 0;
+        earliest = 0;
+        while (leveldb_iter_valid(iter)) {
+            const struct filecache_pdata *pdata;
+            const char *iterkey;
+            const char *path;
+            struct stat stbuf;
+            // We need the key to get the path in case we need to remove the entry from the filecache
+            iterkey = leveldb_iter_key(iter, &klen);
+            path = key2path(iterkey);
+            // if path is null, we've gone past the filecache entries
+            if (path == NULL) break;
+            pdata = (const struct filecache_pdata *)leveldb_iter_value(iter, &klen);
+            log_print(LOG_DEBUG, SECTION_FILECACHE_CLEAN, "filecache_cleanup: Visiting %s :: %s", path, pdata ? pdata->filename : "no pdata");
+            if (pdata) {
+                ++cached_files;
+                // We delete the entry, making pdata invalid, before we might need the filename to unlink,
+                // so store it in fname
+                strncpy(fname, pdata->filename, PATH_MAX);
+                
+                if (stat(fname, &stbuf) != -1) {
+                    total_size += stbuf.st_size;
+                    if (stbuf.st_atime < earliest) earliest = stbuf.st_atime;
+                }
 
-            // If the cache file doesn't exist, delete the entry from the level_db cache
-            ret = access(fname, F_OK);
-            if (ret) {
-                filecache_delete(cache, path, true, &tmpgerr);
-                if (tmpgerr) {
-                    g_propagate_prefixed_error(gerr, tmpgerr, "filecache_cleanup on failed call to access: ");
-                    ++issues;
-                    goto finish;
+                // If the cache file doesn't exist, delete the entry from the level_db cache
+                ret = access(fname, F_OK);
+                if (ret) {
+                    filecache_delete(cache, path, true, &tmpgerr);
+                    if (tmpgerr) {
+                        g_propagate_prefixed_error(gerr, tmpgerr, "filecache_cleanup on failed call to access: ");
+                        ++issues;
+                        goto finish;
+                    }
+                    else {
+                        ++pruned_files;
+                    }
+                }
+                else if ((first && pdata->last_server_update == 0) ||
+                         ((pdata->last_server_update != 0) && (starttime - pdata->last_server_update > age_out))) {
+                    log_print(LOG_DEBUG, SECTION_FILECACHE_CLEAN, "filecache_cleanup: Unlinking %s", fname);
+                    filecache_delete(cache, path, true, &tmpgerr);
+                    if (tmpgerr) {
+                        g_propagate_prefixed_error(gerr, tmpgerr, "filecache_cleanup on aged out: ");
+                        ++issues;
+                        goto finish;
+                    }
+                    else {
+                        // Not specifically true. We could succeed at unlink in filecache_delete
+                        // but return non-zero; still, close enough.
+                        ++unlinked_files;
+                    }
                 }
                 else {
-                    ++pruned_files;
-                }
-            }
-            else if ((first && pdata->last_server_update == 0) ||
-                     ((pdata->last_server_update != 0) && (starttime - pdata->last_server_update > AGE_OUT_THRESHOLD))) {
-                log_print(LOG_DEBUG, SECTION_FILECACHE_CLEAN, "filecache_cleanup: Unlinking %s", fname);
-                filecache_delete(cache, path, true, &tmpgerr);
-                if (tmpgerr) {
-                    g_propagate_prefixed_error(gerr, tmpgerr, "filecache_cleanup on aged out: ");
-                    ++issues;
-                    goto finish;
-                }
-                else {
-                    // Not specifically true. We could succeed at unlink in filecache_delete
-                    // but return non-zero; still, close enough.
-                    ++unlinked_files;
+                    // put a timestamp on the file
+                    ret = utime(fname, NULL);
+                    if (ret) {
+                        log_print(LOG_NOTICE, SECTION_FILECACHE_CLEAN, 
+                                "filecache_cleanup: failed to update timestamp on \"%s\" for \"%s\" from ldb cache: %d - %s", 
+                                fname, path, errno, strerror(errno));
+                    }
                 }
             }
             else {
-                // put a timestamp on the file
-                ret = utime(fname, NULL);
-                if (ret) {
-                    log_print(LOG_NOTICE, SECTION_FILECACHE_CLEAN, "filecache_cleanup: failed to update timestamp on \"%s\" for \"%s\" from ldb cache: %d - %s", fname, path, errno, strerror(errno));
-                }
+                log_print(LOG_NOTICE, SECTION_FILECACHE_CLEAN, "filecache_cleanup: pulled NULL pdata out of cache for %s", path);
             }
+            leveldb_iter_next(iter);
         }
-        else {
-            log_print(LOG_NOTICE, SECTION_FILECACHE_CLEAN, "filecache_cleanup: pulled NULL pdata out of cache for %s", path);
+        if (total_size < max_cache_size) { 
+            done = true;
+        } else {
+            // On the next round, age_out at a point halfway between current earliest and current time
+            time_t time_diff;
+            const time_t two_hours = 2 * 60 * 60;
+            time_diff = time(NULL) - earliest;
+            // Avoid being too aggressive. Leave one hour's worth of files in the cache.
+            if (age_out > two_hours) {
+                age_out = earliest + (time_diff / 2);
+            } else {
+                done = true;
+            }
+            reduce_interval = true;
         }
-        leveldb_iter_next(iter);
     }
 
     leveldb_iter_destroy(iter);
@@ -1797,4 +1829,5 @@ void filecache_cleanup(filecache_t *cache, const char *cache_path, bool first, G
 finish:
     log_print(LOG_INFO, SECTION_FILECACHE_CLEAN, "filecache_cleanup: visited %d cache entries; unlinked %d, pruned %d, had %d issues",
         cached_files, unlinked_files, pruned_files, issues);
+    return reduce_interval;
 }

--- a/src/filecache.c
+++ b/src/filecache.c
@@ -1707,12 +1707,12 @@ bool filecache_cleanup(filecache_t *cache, const char *cache_path, bool first, G
     int issues = 0;
     int pruned_files = 0;
     bool done = false;
-    int total_size = 0;
+    unsigned long total_size = 0;
     time_t earliest = 0;
     // By default, keep any file younger than 8 days old
-    time_t age_out = 691200
-    // Take evasive action if there are more than 128GB in the file cache
-    const int max_cache_size = 128 * 1024 * 1024 * 1024;
+    time_t age_out = 691200;
+    // Take evasive action if there are more than 16GB in the file cache
+    const unsigned long max_cache_size = (unsigned long) (16) *  (1024 * 1024 * 1024);
     bool reduce_interval = false;
 
     BUMP(filecache_cleanup);

--- a/src/filecache.h
+++ b/src/filecache.h
@@ -53,7 +53,7 @@ int filecache_fd(struct fuse_file_info *info);
 void filecache_set_error(struct fuse_file_info *info, int error_code);
 void filecache_forensic_haven(const char *cache_path, filecache_t *cache, const char *path, off_t fsize, GError **gerr);
 void filecache_pdata_move(filecache_t *cache, const char *old_path, const char *new_path, GError **gerr);
-void filecache_cleanup(filecache_t *cache, const char *cache_path, bool first, GError **gerr);
+bool filecache_cleanup(filecache_t *cache, const char *cache_path, bool first, GError **gerr);
 struct curl_slist* enhanced_logging(struct curl_slist *slist, int log_level, int section, const char *format, ...);
 
 #endif

--- a/src/filecache.h
+++ b/src/filecache.h
@@ -55,5 +55,6 @@ void filecache_forensic_haven(const char *cache_path, filecache_t *cache, const 
 void filecache_pdata_move(filecache_t *cache, const char *old_path, const char *new_path, GError **gerr);
 bool filecache_cleanup(filecache_t *cache, const char *cache_path, bool first, GError **gerr);
 struct curl_slist* enhanced_logging(struct curl_slist *slist, int log_level, int section, const char *format, ...);
+void filecache_cached_file_size(filecache_t *cache, const char *path, off_t *size, GError **gerr);
 
 #endif

--- a/src/fusedav.c
+++ b/src/fusedav.c
@@ -1090,6 +1090,7 @@ static int dav_fgetattr(const char *path, struct stat *stbuf, struct fuse_file_i
         return processed_gerror("dav_fgetattr: ", path, &gerr);
     }
     log_print(LOG_DEBUG, SECTION_FUSEDAV_STAT, "Done: dav_fgetattr(%s)", path?path:"null path");
+    log_print(LOG_NOTICE, SECTION_FUSEDAV_STAT, "Done: dav_fgetattr(%s); size: %d", path?path:"null path", stbuf->st_size);
 
     return 0;
 }
@@ -1113,6 +1114,7 @@ static int dav_getattr(const char *path, struct stat *stbuf) {
     }
     print_stat(stbuf, "dav_getattr", path);
     log_print(LOG_DEBUG, SECTION_FUSEDAV_STAT, "Done: dav_getattr(%s)", path);
+    log_print(LOG_NOTICE, SECTION_FUSEDAV_STAT, "Done: dav_getattr(%s); size: %d", path?path:"null path", stbuf->st_size);
 
     return 0;
 }

--- a/src/fusedav.c
+++ b/src/fusedav.c
@@ -2238,7 +2238,7 @@ static void *cache_cleanup(void *ptr) {
     // from errant stat and file caches
     bool first = true;
     // Run cache cleanup once a day by default (24 * 60 * 60)
-    time_t cache_cleanup_interval = 86400
+    time_t cache_cleanup_interval = 86400;
     const time_t three_hours = 3 * 60 * 60;
 
     log_print(LOG_DEBUG, SECTION_FUSEDAV_DEFAULT, "enter cache_cleanup");

--- a/src/session.c
+++ b/src/session.c
@@ -206,7 +206,8 @@ int session_config_init(char *base, char *ca_cert, char *client_cert, bool grace
     }
     else {
         // If using shortnames, make the cluster the same as the domain.
-        log_print(LOG_NOTICE, SECTION_SESSION_DEFAULT, "session_config_init: no cluster name in base: %s", base);
+        log_print(LOG_NOTICE, SECTION_SESSION_DEFAULT, "session_config_init: no cluster name in base: %s, using domain: %s", 
+            base, filesystem_domain);
         filesystem_cluster = g_strdup(filesystem_domain);
     }
     uriFreeUriMembersA(&uri);

--- a/src/session.c
+++ b/src/session.c
@@ -200,13 +200,14 @@ int session_config_init(char *base, char *ca_cert, char *client_cert, bool grace
     filesystem_domain = strndup(uri.hostText.first, uri.hostText.afterLast - uri.hostText.first);
     filesystem_port = strndup(uri.portText.first, uri.portText.afterLast - uri.portText.first);
     firstdot = strchr(uri.hostText.first, '.');
+    // If we change the format of the base, this logic might no longer find the cluster
     if (firstdot) {
         filesystem_cluster = strndup(uri.hostText.first, firstdot - uri.hostText.first);
     }
     else {
-        /* Failure */
-        log_print(LOG_CRIT, SECTION_SESSION_DEFAULT, "session_config_init: error on uriParse finding cluster name: %s", base);
-        asprintf(&filesystem_cluster, "unknown");
+        // If using shortnames, make the cluster the same as the domain.
+        log_print(LOG_NOTICE, SECTION_SESSION_DEFAULT, "session_config_init: no cluster name in base: %s", base);
+        filesystem_cluster = g_strdup(filesystem_domain);
     }
     uriFreeUriMembersA(&uri);
 

--- a/src/statcache.c
+++ b/src/statcache.c
@@ -678,8 +678,8 @@ void stat_cache_value_set(stat_cache_t *cache, const char *path, struct stat_cac
     value->local_generation = stat_cache_get_local_generation();
 
     key = path2key(path, false);
-    log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, "%s: %s (mode %04o: updated %lu: loc_gen %lu: atime %lu: mtime %lu)",
-        funcname, key, value->st.st_mode, value->updated, value->local_generation, value->st.st_atime, value->st.st_mtime);
+    log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, "%s: %s (mode %04o: size: %d; updated %lu: loc_gen %lu: atime %lu: mtime %lu)",
+        funcname, key, value->st.st_mode, value->st.st_size, value->updated, value->local_generation, value->st.st_atime, value->st.st_mtime);
 
     options = leveldb_writeoptions_create();
     leveldb_put(cache, options, key, strlen(key) + 1, (char *) value, sizeof(struct stat_cache_value), &errptr);

--- a/src/util.c
+++ b/src/util.c
@@ -144,6 +144,30 @@ static void leveldb_error_test(void) {
     }
 }
 
+/* test what happens on file size mismatch */
+static void sizemismatch_test(void) {
+    static int fdx = no_error;
+    static int tdx = no_error;
+    const int iters = 4096; // @TODO I just made this number up; figure out a better one!
+
+    for (int iter = 0; iter < iters; iter++) {
+        // Sleep 11 seconds between injections
+        sleep(11);
+
+        // flop between mismatch and no_error
+
+        if (tdx == no_error) tdx = fusedav_error_sizemismatch;
+        else tdx = no_error;
+
+        log_print(LOG_NOTICE, SECTION_UTIL_DEFAULT, "fce: %d Uninjecting %d; injecting %d", inject_error_count, fdx, tdx);
+
+        // Make the new location true but turn off the locations for the old location.
+        inject_error_list[tdx] = true;
+        inject_error_list[fdx] = false;
+        fdx = tdx;
+    }
+}
+
 /* test what happens on a write error */
 static void writewrite_test(void) {
     static int fdx = no_error;
@@ -323,6 +347,7 @@ void *inject_error_mechanism(__unused void *ptr) {
 
     while (true) {
 
+        /*
         log_print(LOG_NOTICE, SECTION_UTIL_DEFAULT, "inject_error_mechanism: Starting rand_test");
         rand_test();
 
@@ -343,6 +368,10 @@ void *inject_error_mechanism(__unused void *ptr) {
 
         log_print(LOG_NOTICE, SECTION_UTIL_DEFAULT, "inject_error_mechanism: Starting curl error capture test");
         curl_error_capture_test();
+        */
+
+        log_print(LOG_NOTICE, SECTION_UTIL_DEFAULT, "inject_error_mechanism: Starting file size mismatch test");
+        sizemismatch_test();
     }
 
     free(inject_error_list);

--- a/src/util.h
+++ b/src/util.h
@@ -59,6 +59,7 @@ void *inject_error_mechanism(void *ptr);
 #define fusedav_error_cunlinkcurl 8
 #define fusedav_error_propfindsession 9
 #define fusedav_error_propfindhead 10
+#define fusedav_error_sizemismatch 11
 
 #define filecache_error_init1 20
 #define filecache_error_init2 21

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -90,6 +90,36 @@ trunc = $(testdir)/trunc
 # number of write iters 'trunc-flags=-v -r 8 -f 8 -s 32 -i 16'
 trunc-flags =
 
+# Needs to be run from outside of files directory since it accesses the file cache in the binding directory
+stat-vs-fstat = $(testdir)/stat-vs-fstat
+# -v for verbose, -r# for number of rounds, -f# for number of files, -s# for size of write, -i# for
+# number of write iters 'stat-vs-fstat-flags=-v -r 8 -f 8 -s 32 -i 16'
+stat-vs-fstat-flags =
+
+# Needs to be run from outside of files directory since it accesses the file cache in the binding directory
+stat-stat = $(testdir)/stat-stat
+# -v for verbose, -r# for number of rounds, -f# for number of files, -s# for size of write, -i# for
+# number of write iters 'stat-stat-flags=-v -s 32 -i 16'
+stat-stat-flags =
+
+# Needs to be run from outside of files directory since it accesses the file cache in the binding directory
+stat-fstat = $(testdir)/stat-fstat
+# -v for verbose, -r# for number of rounds, -f# for number of files, -s# for size of write, -i# for
+# number of write iters 'stat-fstat-flags=-v -s 32 -i 16'
+stat-fstat-flags =
+
+# Needs to be run from outside of files directory since it accesses the file cache in the binding directory
+stat-fstat-unlink = $(testdir)/stat-fstat-unlink
+# -v for verbose, -r# for number of rounds, -f# for number of files, -s# for size of write, -i# for
+# number of write iters 'stat-fstat-unlink-flags=-v -s 32 -i 16'
+stat-fstat-unlink-flags =
+
+# Needs to be run from outside of files directory since it accesses the file cache in the binding directory
+stat-stat-unlink = $(testdir)/stat-stat-unlink
+# -v for verbose, -r# for number of rounds, -f# for number of files, -s# for size of write, -i# for
+# number of write iters 'stat-stat-unlink-flags=-v -s 32 -i 16'
+stat-stat-unlink-flags =
+
 pfbackoff = $(testdir)/pfbackoff.sh
 # -v for verbose, -n# for number of rounds
 # number of iters 'pfbackoff-flags=-v -n 8'
@@ -108,7 +138,7 @@ saintmode-writes-nginx = $(testdir)/saintmode-writes-nginx.sh
 saintmode-writes-nginx-flags =
 
 unhealthy-haproxy = $(testdir)/unhealthy-haproxy.sh
-# -v for verbose, -i# for number of write iters'trunc-flags=-v -i 16'
+# -v for verbose, -i# for number of write iters'unhealthy-haproxy-flags=-v -i 16'
 unhealthy-haproxy-flags =
 
 # to run this test by invoking the Makefile, add binding=<binding id> to the make line
@@ -286,6 +316,36 @@ run-trunc: $(trunc)
 	$(trunc) $(trunc-flags)
 
 $(trunc): $(testdir)/trunc.c
+	cc $< -std=c99 -g -o $@
+
+run-stat-vs-fstat: $(stat-vs-fstat)
+	$(stat-vs-fstat) $(stat-vs-fstat-flags)
+
+$(stat-vs-fstat): $(testdir)/stat-vs-fstat.c
+	cc $< -std=c99 -g -o $@
+
+run-stat-stat: $(stat-stat)
+	$(stat-stat) $(stat-stat-flags)
+
+$(stat-stat): $(testdir)/stat-stat.c
+	cc $< -std=c99 -g -o $@
+
+run-stat-fstat: $(stat-fstat)
+	$(stat-fstat) $(stat-fstat-flags)
+
+$(stat-fstat): $(testdir)/stat-fstat.c
+	cc $< -std=c99 -g -o $@
+
+run-stat-fstat-unlink: $(stat-fstat-unlink)
+	$(stat-fstat-unlink) $(stat-fstat-unlink-flags)
+
+$(stat-fstat-unlink): $(testdir)/stat-fstat-unlink.c
+	cc $< -std=c99 -g -o $@
+
+run-stat-stat-unlink: $(stat-stat-unlink)
+	$(stat-stat-unlink) $(stat-stat-unlink-flags)
+
+$(stat-stat-unlink): $(testdir)/stat-stat-unlink.c
 	cc $< -std=c99 -g -o $@
 
 run-timestamptest:

--- a/tests/stat-fstat-unlink.c
+++ b/tests/stat-fstat-unlink.c
@@ -1,0 +1,116 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+static bool verbose = false;
+
+static void usage() {
+    printf("One arg, -v for verbose\n");
+    exit(0);
+}
+
+static void v_printf(const char *fmt, ...) {
+    if (verbose) {
+        va_list ap;
+        va_start(ap, fmt);
+        vfprintf(stdout, fmt, ap);
+        va_end(ap);
+    }
+}
+
+int process(const int write_size, const int write_iters) {
+    int failed = 0;
+    int fd;
+    struct stat sbuf;
+    char ch = 'A';
+    char buf[write_size];
+    char filename[4096];
+    int ret;
+
+    v_printf("s%d i%d\n", write_size, write_iters);
+
+    for (int idx = 0; idx < write_size; idx++) {
+        buf[idx] = ch;
+        ++ch;
+        if (ch > 'z') ch = 'A';
+    }
+
+    strcpy(filename, "files/stat-stat");
+
+    // Create a series of files
+    fd = open(filename, O_RDWR | O_CREAT | O_TRUNC, 0);
+
+    // Make each file a larger size than the one before
+    for (int kdx = 0; kdx < write_iters; kdx++) {
+        write(fd, buf, write_size);
+    }
+
+    ret = unlink(filename);
+    if (ret < 0) {
+        v_printf("ERROR on unlink: %d: %s\n", errno, strerror(errno));
+        ++failed;
+    }
+    ret = fstat(fd, &sbuf);
+    if (ret < 0) {
+        v_printf("ERROR on stat or fstat: %d: %s\n", errno, strerror(errno));
+        ++failed;
+    }
+    else {
+        int expected_size;
+        expected_size = write_size * write_iters;
+
+        // fstat
+        if (sbuf.st_size == expected_size) {
+            v_printf("stat-stat After write, fstat got expected size of %d\n", sbuf.st_size);
+        }
+        else {
+            v_printf("stat-stat After write, fstat ERROR expected %d size is %d\n", expected_size, sbuf.st_size);
+            ++failed;
+        }
+    }
+    close(fd);
+    return failed;
+}
+
+int main(int argc, char *argv[]) {
+    int ret;
+    int opt;
+    int write_size = 32;
+    int write_iters = 16;
+    int failed;
+
+    while ((opt = getopt (argc, argv, "vhf:r:s:i:")) != -1) {
+        switch (opt)
+        {
+            case 'v':
+                verbose = true;
+                break;
+            case 's':
+                write_size = strtol(optarg, NULL, 10);
+                break;
+            case 'i':
+                write_iters = strtol(optarg, NULL, 10);
+                break;
+            case 'h':
+            case '?':
+            default:
+                usage ();
+        }
+    }
+
+    failed = process(write_size, write_iters);
+    if (failed > 0) {
+        printf("FAIL: failures %d\n", failed);
+    }
+    else {
+        printf("PASS:\n");
+    }
+}

--- a/tests/stat-fstat.c
+++ b/tests/stat-fstat.c
@@ -1,0 +1,111 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+static bool verbose = false;
+
+static void usage() {
+    printf("One arg, -v for verbose\n");
+    exit(0);
+}
+
+static void v_printf(const char *fmt, ...) {
+    if (verbose) {
+        va_list ap;
+        va_start(ap, fmt);
+        vfprintf(stdout, fmt, ap);
+        va_end(ap);
+    }
+}
+
+int process(const int write_size, const int write_iters) {
+    int failed = 0;
+    int fd;
+    struct stat sbuf;
+    char ch = 'A';
+    char buf[write_size];
+    char filename[4096];
+    int ret;
+
+    v_printf("s%d i%d\n", write_size, write_iters);
+
+    for (int idx = 0; idx < write_size; idx++) {
+        buf[idx] = ch;
+        ++ch;
+        if (ch > 'z') ch = 'A';
+    }
+
+    strcpy(filename, "files/stat-stat");
+
+    // Create a series of files
+    fd = open(filename, O_RDWR | O_CREAT | O_TRUNC, 0);
+
+    // Make each file a larger size than the one before
+    for (int kdx = 0; kdx < write_iters; kdx++) {
+        write(fd, buf, write_size);
+    }
+
+    ret = fstat(fd, &sbuf);
+    if (ret < 0) {
+        v_printf("ERROR on stat or fstat: %d: %s\n", errno, strerror(errno));
+        ++failed;
+    }
+    else {
+        int expected_size;
+        expected_size = write_size * write_iters;
+
+        // fstat
+        if (sbuf.st_size == expected_size) {
+            v_printf("stat-stat After write, fstat got expected size of %d\n", sbuf.st_size);
+        }
+        else {
+            v_printf("stat-stat After write, fstat ERROR expected %d size is %d\n", expected_size, sbuf.st_size);
+            ++failed;
+        }
+    }
+    close(fd);
+    return failed;
+}
+
+int main(int argc, char *argv[]) {
+    int ret;
+    int opt;
+    int write_size = 32;
+    int write_iters = 16;
+    int failed;
+
+    while ((opt = getopt (argc, argv, "vhf:r:s:i:")) != -1) {
+        switch (opt)
+        {
+            case 'v':
+                verbose = true;
+                break;
+            case 's':
+                write_size = strtol(optarg, NULL, 10);
+                break;
+            case 'i':
+                write_iters = strtol(optarg, NULL, 10);
+                break;
+            case 'h':
+            case '?':
+            default:
+                usage ();
+        }
+    }
+
+    failed = process(write_size, write_iters);
+    if (failed > 0) {
+        printf("FAIL: failures %d\n", failed);
+    }
+    else {
+        printf("PASS:\n");
+    }
+}

--- a/tests/stat-stat-unlink.c
+++ b/tests/stat-stat-unlink.c
@@ -1,0 +1,116 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+static bool verbose = false;
+
+static void usage() {
+    printf("One arg, -v for verbose\n");
+    exit(0);
+}
+
+static void v_printf(const char *fmt, ...) {
+    if (verbose) {
+        va_list ap;
+        va_start(ap, fmt);
+        vfprintf(stdout, fmt, ap);
+        va_end(ap);
+    }
+}
+
+int process(const int write_size, const int write_iters) {
+    int failed = 0;
+    int fd;
+    struct stat sbuf;
+    char ch = 'A';
+    char buf[write_size];
+    char filename[4096];
+    int ret;
+
+    v_printf("s%d i%d\n", write_size, write_iters);
+
+    for (int idx = 0; idx < write_size; idx++) {
+        buf[idx] = ch;
+        ++ch;
+        if (ch > 'z') ch = 'A';
+    }
+
+    strcpy(filename, "files/stat-stat");
+
+    // Create a series of files
+    fd = open(filename, O_RDWR | O_CREAT | O_TRUNC, 0);
+
+    // Make each file a larger size than the one before
+    for (int kdx = 0; kdx < write_iters; kdx++) {
+        write(fd, buf, write_size);
+    }
+
+    ret = unlink(filename);
+    if (ret < 0) {
+        v_printf("ERROR on unlink: %d: %s\n", errno, strerror(errno));
+        ++failed;
+    }
+    ret = stat(filename, &sbuf);
+    if (ret < 0) {
+        v_printf("ERROR on stat or fstat: %d: %s\n", errno, strerror(errno));
+        ++failed;
+    }
+    else {
+        int expected_size;
+        expected_size = write_size * write_iters;
+
+        // fstat
+        if (sbuf.st_size == expected_size) {
+            v_printf("stat-stat After write, fstat got expected size of %d\n", sbuf.st_size);
+        }
+        else {
+            v_printf("stat-stat After write, fstat ERROR expected %d size is %d\n", expected_size, sbuf.st_size);
+            ++failed;
+        }
+    }
+    close(fd);
+    return failed;
+}
+
+int main(int argc, char *argv[]) {
+    int ret;
+    int opt;
+    int write_size = 32;
+    int write_iters = 16;
+    int failed;
+
+    while ((opt = getopt (argc, argv, "vhf:r:s:i:")) != -1) {
+        switch (opt)
+        {
+            case 'v':
+                verbose = true;
+                break;
+            case 's':
+                write_size = strtol(optarg, NULL, 10);
+                break;
+            case 'i':
+                write_iters = strtol(optarg, NULL, 10);
+                break;
+            case 'h':
+            case '?':
+            default:
+                usage ();
+        }
+    }
+
+    failed = process(write_size, write_iters);
+    if (failed > 0) {
+        printf("FAIL: failures %d\n", failed);
+    }
+    else {
+        printf("PASS:\n");
+    }
+}

--- a/tests/stat-stat.c
+++ b/tests/stat-stat.c
@@ -1,0 +1,112 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+static bool verbose = false;
+
+static void usage() {
+    printf("One arg, -v for verbose\n");
+    exit(0);
+}
+
+static void v_printf(const char *fmt, ...) {
+    if (verbose) {
+        va_list ap;
+        va_start(ap, fmt);
+        vfprintf(stdout, fmt, ap);
+        va_end(ap);
+    }
+}
+
+int process(const int write_size, const int write_iters) {
+    int failed = 0;
+    int fd;
+    struct stat sbuf;
+    char ch = 'A';
+    char buf[write_size];
+    char filename[4096];
+    int ret;
+
+    v_printf("s%d i%d\n", write_size, write_iters);
+
+    for (int idx = 0; idx < write_size; idx++) {
+        buf[idx] = ch;
+        ++ch;
+        if (ch > 'z') ch = 'A';
+    }
+
+    strcpy(filename, "files/stat-stat");
+
+    // Create a series of files
+    fd = open(filename, O_RDWR | O_CREAT | O_TRUNC, 0);
+
+    // Make each file a larger size than the one before
+    for (int kdx = 0; kdx < write_iters; kdx++) {
+        write(fd, buf, write_size);
+    }
+
+    ret = stat(filename, &sbuf);
+    // ret = fstat(fd, &sbuf[idx]);
+    if (ret < 0) {
+        v_printf("ERROR on stat or fstat: %d: %s\n", errno, strerror(errno));
+        ++failed;
+    }
+    else {
+        int expected_size;
+        expected_size = write_size * write_iters;
+
+        // fstat
+        if (sbuf.st_size == expected_size) {
+            v_printf("stat-stat After write, fstat got expected size of %d\n", sbuf.st_size);
+        }
+        else {
+            v_printf("stat-stat After write, fstat ERROR expected %d size is %d\n", expected_size, sbuf.st_size);
+            ++failed;
+        }
+    }
+    close(fd);
+    return failed;
+}
+
+int main(int argc, char *argv[]) {
+    int ret;
+    int opt;
+    int write_size = 32;
+    int write_iters = 16;
+    int failed;
+
+    while ((opt = getopt (argc, argv, "vhf:r:s:i:")) != -1) {
+        switch (opt)
+        {
+            case 'v':
+                verbose = true;
+                break;
+            case 's':
+                write_size = strtol(optarg, NULL, 10);
+                break;
+            case 'i':
+                write_iters = strtol(optarg, NULL, 10);
+                break;
+            case 'h':
+            case '?':
+            default:
+                usage ();
+        }
+    }
+
+    failed = process(write_size, write_iters);
+    if (failed > 0) {
+        printf("FAIL: failures %d\n", failed);
+    }
+    else {
+        printf("PASS:\n");
+    }
+}

--- a/tests/stat-vs-fstat.c
+++ b/tests/stat-vs-fstat.c
@@ -1,0 +1,138 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+static bool verbose = false;
+
+static void usage() {
+    printf("One arg, -v for verbose\n");
+    exit(0);
+}
+
+static void v_printf(const char *fmt, ...) {
+    if (verbose) {
+        va_list ap;
+        va_start(ap, fmt);
+        vfprintf(stdout, fmt, ap);
+        va_end(ap);
+    }
+}
+
+int process(const int rounds, const int num_files, const int write_size, const int write_iters) {
+    int failed = 0;
+    int fd[num_files];
+    struct stat fsbuf[num_files];
+    struct stat sbuf[num_files];
+    char ch = 'A';
+    char buf[write_size];
+    char basename[4096];
+    char filename[4096];
+    int sret;
+    int fsret;
+
+    v_printf("r%d n%d s%d i%d\n", rounds, num_files, write_size, write_iters);
+
+    for (int idx = 0; idx < write_size; idx++) {
+        buf[idx] = ch;
+        ++ch;
+        if (ch > 'z') ch = 'A';
+    }
+
+    strcpy(basename, "files/stat-vs-fstat-");
+
+    // Create a series of files
+    for (int idx = 1; idx <= num_files; idx++) {
+        sprintf(filename, "%s%d", basename, idx-1);
+        fd[idx] = open(filename, O_RDWR | O_CREAT | O_TRUNC, 0);
+
+        // Make each file a larger size than the one before
+        for (int kdx = 0; kdx < write_iters; kdx++) {
+            write(fd[idx], buf, idx * write_size);
+        }
+    }
+    for (int idx = 1; idx <= num_files; idx++) {
+        sprintf(filename, "%s%d", basename, idx);
+        fsret = fstat(fd[idx], &fsbuf[idx]);
+        // sret = stat(filename, &sbuf[idx]);
+        if (fsret < 0 || sret < 0) {
+            v_printf("ERROR on stat or fstat\n");
+            ++failed;
+        }
+        else {
+            int expected_size;
+            expected_size = idx * write_size * write_iters;
+
+            // fstat
+            if (fsbuf[idx].st_size == expected_size) {
+                v_printf("stat-vs-fstat-%d After write, fstat got expected size of %d\n", idx, fsbuf[idx].st_size);
+            }
+            else {
+                v_printf("stat-vs-fstat-%d After write, fstat ERROR expected %d size is %d\n", idx, expected_size, fsbuf[idx].st_size);
+                ++failed;
+            }
+   
+            /*
+            // stat
+            if (sbuf[idx].st_size == expected_size) {
+                v_printf("stat-vs-fstat-%d After write, stat got expected size of %d\n", idx, sbuf[idx].st_size);
+            }
+            else {
+                v_printf("stat-vs-fstat-%d After write, stat ERROR expected %d size is %d\n", idx, expected_size, sbuf[idx].st_size);
+                ++failed;
+            }
+            */
+        }
+        close(fd[idx]);
+    }
+    return failed;
+}
+
+int main(int argc, char *argv[]) {
+    int ret;
+    int opt;
+    int num_files = 8; // default for unit test
+    int rounds = 8;
+    int write_size = 32;
+    int write_iters = 16;
+    int failed;
+
+    while ((opt = getopt (argc, argv, "vhf:r:s:i:")) != -1) {
+        switch (opt)
+        {
+            case 'v':
+                verbose = true;
+                break;
+            case 'f':
+                num_files = strtol(optarg, NULL, 10);
+                break;
+            case 'r':
+                rounds = strtol(optarg, NULL, 10);
+                break;
+            case 's':
+                write_size = strtol(optarg, NULL, 10);
+                break;
+            case 'i':
+                write_iters = strtol(optarg, NULL, 10);
+                break;
+            case 'h':
+            case '?':
+            default:
+                usage ();
+        }
+    }
+
+    failed = process(rounds, num_files, write_size, write_iters);
+    if (failed > 0) {
+        printf("FAIL: failures %d\n", failed);
+    }
+    else {
+        printf("PASS:\n");
+    }
+}


### PR DESCRIPTION
Three issues in this PR
1. Enable short names. Previously, long names were expected in the fileserver line. If there wasn't a dot in the appropriate place, the cluster name was not set. Now use the domain name for the cluster name
2. Attempt to prevent bindings from using too much disk space for file caching.
3. Prevent issue where responses were made from fusedav returns where content-length was different from the number of bytes in the body. When we see a file getting new content, delete the entry from the stat cache and let it get reset on subsequent request.