### PR TITLE
Content length mismatch (#467) (#468)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ config.h.in
 tests/perfanalysis-read
 tests/perfanalysis-write
 tests/one-open-many-writes
+tests/stat-fstat
+tests/stat-fstat-unlink
+tests/stat-stat
+tests/stat-stat-unlink
+tests/stat-vs-fstat
 /src/*.plist
 _trial_temp*
 

--- a/src/filecache.h
+++ b/src/filecache.h
@@ -53,7 +53,8 @@ int filecache_fd(struct fuse_file_info *info);
 void filecache_set_error(struct fuse_file_info *info, int error_code);
 void filecache_forensic_haven(const char *cache_path, filecache_t *cache, const char *path, off_t fsize, GError **gerr);
 void filecache_pdata_move(filecache_t *cache, const char *old_path, const char *new_path, GError **gerr);
-void filecache_cleanup(filecache_t *cache, const char *cache_path, bool first, GError **gerr);
+bool filecache_cleanup(filecache_t *cache, const char *cache_path, bool first, GError **gerr);
 struct curl_slist* enhanced_logging(struct curl_slist *slist, int log_level, int section, const char *format, ...);
+void filecache_cached_file_size(filecache_t *cache, const char *path, off_t *size, GError **gerr);
 
 #endif

--- a/src/session.c
+++ b/src/session.c
@@ -200,13 +200,15 @@ int session_config_init(char *base, char *ca_cert, char *client_cert, bool grace
     filesystem_domain = strndup(uri.hostText.first, uri.hostText.afterLast - uri.hostText.first);
     filesystem_port = strndup(uri.portText.first, uri.portText.afterLast - uri.portText.first);
     firstdot = strchr(uri.hostText.first, '.');
+    // If we change the format of the base, this logic might no longer find the cluster
     if (firstdot) {
         filesystem_cluster = strndup(uri.hostText.first, firstdot - uri.hostText.first);
     }
     else {
-        /* Failure */
-        log_print(LOG_CRIT, SECTION_SESSION_DEFAULT, "session_config_init: error on uriParse finding cluster name: %s", base);
-        asprintf(&filesystem_cluster, "unknown");
+        // If using shortnames, make the cluster the same as the domain.
+        log_print(LOG_NOTICE, SECTION_SESSION_DEFAULT, "session_config_init: no cluster name in base: %s, using domain: %s", 
+            base, filesystem_domain);
+        filesystem_cluster = g_strdup(filesystem_domain);
     }
     uriFreeUriMembersA(&uri);
 

--- a/src/statcache.c
+++ b/src/statcache.c
@@ -36,7 +36,6 @@
 #include "stats.h"
 #include "fusedav-statsd.h"
 
-#define CACHE_TIMEOUT 3
 // The version of the data stored in the stat cache
 const uint64_t STAT_CACHE_DATA_VERSION = 2;
 static uint64_t data_version = 0;
@@ -383,7 +382,7 @@ struct stat_cache_value *stat_cache_value_get(stat_cache_t *cache, const char *p
 
         // Keep stats for each second 0-6, then bucket everything over 6
         stats_histo("sc_value_get", time_since, 6, pfsamplerate);
-        if (time_since > CACHE_TIMEOUT) {
+        if (time_since > STAT_CACHE_NEGATIVE_TTL) {
             char *directory;
             time_t directory_updated;
 
@@ -411,7 +410,7 @@ struct stat_cache_value *stat_cache_value_get(stat_cache_t *cache, const char *p
             log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, "stat_cache_value_get: Directory contents for %s are %lu seconds old.", 
                     directory, time_since);
             free(directory);
-            if (time_since > CACHE_TIMEOUT) {
+            if (time_since > STAT_CACHE_NEGATIVE_TTL) {
                 log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, 
                         "stat_cache_value_get: Parent directory for %s is too old (%lu seconds).", 
                         path, time_since);
@@ -679,8 +678,8 @@ void stat_cache_value_set(stat_cache_t *cache, const char *path, struct stat_cac
     value->local_generation = stat_cache_get_local_generation();
 
     key = path2key(path, false);
-    log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, "%s: %s (mode %04o: updated %lu: loc_gen %lu: atime %lu: mtime %lu)",
-        funcname, key, value->st.st_mode, value->updated, value->local_generation, value->st.st_atime, value->st.st_mtime);
+    log_print(LOG_DEBUG, SECTION_STATCACHE_CACHE, "%s: %s (mode %04o: size: %d; updated %lu: loc_gen %lu: atime %lu: mtime %lu)",
+        funcname, key, value->st.st_mode, value->st.st_size, value->updated, value->local_generation, value->st.st_atime, value->st.st_mtime);
 
     options = leveldb_writeoptions_create();
     leveldb_put(cache, options, key, strlen(key) + 1, (char *) value, sizeof(struct stat_cache_value), &errptr);
@@ -747,7 +746,7 @@ void stat_cache_delete_parent(stat_cache_t *cache, const char *path, GError **ge
             g_propagate_prefixed_error(gerr, tmpgerr, "stat_cache_delete_parent: ");
         }
         else {
-            stat_cache_updated_children(cache, p, time(NULL) - CACHE_TIMEOUT - 1, &tmpgerr);
+            stat_cache_updated_children(cache, p, time(NULL) - STAT_CACHE_NEGATIVE_TTL - 1, &tmpgerr);
             if (tmpgerr) {
                 g_propagate_prefixed_error(gerr, tmpgerr, "stat_cache_delete_parent: ");
             }
@@ -762,7 +761,7 @@ void stat_cache_delete_parent(stat_cache_t *cache, const char *path, GError **ge
             g_propagate_prefixed_error(gerr, tmpgerr, "stat_cache_delete_parent: no parent path");
         }
         else {
-            stat_cache_updated_children(cache, path, time(NULL) - CACHE_TIMEOUT - 1, &tmpgerr);
+            stat_cache_updated_children(cache, path, time(NULL) - STAT_CACHE_NEGATIVE_TTL - 1, &tmpgerr);
             if (tmpgerr) {
                 g_propagate_prefixed_error(gerr, tmpgerr, "stat_cache_delete_parent: no parent path");
             }
@@ -902,7 +901,7 @@ int stat_cache_enumerate(stat_cache_t *cache, const char *path_prefix, void (*f)
 
         // Check for cache values which are too old; but timestamp = 0 needs to trigger below
         current_time = time(NULL);
-        if (current_time - timestamp > CACHE_TIMEOUT) {
+        if (current_time - timestamp > STAT_CACHE_NEGATIVE_TTL) {
             log_print(LOG_DEBUG, SECTION_STATCACHE_ITER, "cache value too old: %s %u", path_prefix, (unsigned)timestamp);
             return -STAT_CACHE_OLD_DATA;
         }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -90,6 +90,36 @@ trunc = $(testdir)/trunc
 # number of write iters 'trunc-flags=-v -r 8 -f 8 -s 32 -i 16'
 trunc-flags =
 
+# Needs to be run from outside of files directory since it accesses the file cache in the binding directory
+stat-vs-fstat = $(testdir)/stat-vs-fstat
+# -v for verbose, -r# for number of rounds, -f# for number of files, -s# for size of write, -i# for
+# number of write iters 'stat-vs-fstat-flags=-v -r 8 -f 8 -s 32 -i 16'
+stat-vs-fstat-flags =
+
+# Needs to be run from outside of files directory since it accesses the file cache in the binding directory
+stat-stat = $(testdir)/stat-stat
+# -v for verbose, -r# for number of rounds, -f# for number of files, -s# for size of write, -i# for
+# number of write iters 'stat-stat-flags=-v -s 32 -i 16'
+stat-stat-flags =
+
+# Needs to be run from outside of files directory since it accesses the file cache in the binding directory
+stat-fstat = $(testdir)/stat-fstat
+# -v for verbose, -r# for number of rounds, -f# for number of files, -s# for size of write, -i# for
+# number of write iters 'stat-fstat-flags=-v -s 32 -i 16'
+stat-fstat-flags =
+
+# Needs to be run from outside of files directory since it accesses the file cache in the binding directory
+stat-fstat-unlink = $(testdir)/stat-fstat-unlink
+# -v for verbose, -r# for number of rounds, -f# for number of files, -s# for size of write, -i# for
+# number of write iters 'stat-fstat-unlink-flags=-v -s 32 -i 16'
+stat-fstat-unlink-flags =
+
+# Needs to be run from outside of files directory since it accesses the file cache in the binding directory
+stat-stat-unlink = $(testdir)/stat-stat-unlink
+# -v for verbose, -r# for number of rounds, -f# for number of files, -s# for size of write, -i# for
+# number of write iters 'stat-stat-unlink-flags=-v -s 32 -i 16'
+stat-stat-unlink-flags =
+
 pfbackoff = $(testdir)/pfbackoff.sh
 # -v for verbose, -n# for number of rounds
 # number of iters 'pfbackoff-flags=-v -n 8'
@@ -108,7 +138,7 @@ saintmode-writes-nginx = $(testdir)/saintmode-writes-nginx.sh
 saintmode-writes-nginx-flags =
 
 unhealthy-haproxy = $(testdir)/unhealthy-haproxy.sh
-# -v for verbose, -i# for number of write iters'trunc-flags=-v -i 16'
+# -v for verbose, -i# for number of write iters'unhealthy-haproxy-flags=-v -i 16'
 unhealthy-haproxy-flags =
 
 # to run this test by invoking the Makefile, add binding=<binding id> to the make line
@@ -286,6 +316,36 @@ run-trunc: $(trunc)
 	$(trunc) $(trunc-flags)
 
 $(trunc): $(testdir)/trunc.c
+	cc $< -std=c99 -g -o $@
+
+run-stat-vs-fstat: $(stat-vs-fstat)
+	$(stat-vs-fstat) $(stat-vs-fstat-flags)
+
+$(stat-vs-fstat): $(testdir)/stat-vs-fstat.c
+	cc $< -std=c99 -g -o $@
+
+run-stat-stat: $(stat-stat)
+	$(stat-stat) $(stat-stat-flags)
+
+$(stat-stat): $(testdir)/stat-stat.c
+	cc $< -std=c99 -g -o $@
+
+run-stat-fstat: $(stat-fstat)
+	$(stat-fstat) $(stat-fstat-flags)
+
+$(stat-fstat): $(testdir)/stat-fstat.c
+	cc $< -std=c99 -g -o $@
+
+run-stat-fstat-unlink: $(stat-fstat-unlink)
+	$(stat-fstat-unlink) $(stat-fstat-unlink-flags)
+
+$(stat-fstat-unlink): $(testdir)/stat-fstat-unlink.c
+	cc $< -std=c99 -g -o $@
+
+run-stat-stat-unlink: $(stat-stat-unlink)
+	$(stat-stat-unlink) $(stat-stat-unlink-flags)
+
+$(stat-stat-unlink): $(testdir)/stat-stat-unlink.c
 	cc $< -std=c99 -g -o $@
 
 run-timestamptest:

--- a/tests/stat-fstat-unlink.c
+++ b/tests/stat-fstat-unlink.c
@@ -1,0 +1,116 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+static bool verbose = false;
+
+static void usage() {
+    printf("One arg, -v for verbose\n");
+    exit(0);
+}
+
+static void v_printf(const char *fmt, ...) {
+    if (verbose) {
+        va_list ap;
+        va_start(ap, fmt);
+        vfprintf(stdout, fmt, ap);
+        va_end(ap);
+    }
+}
+
+int process(const int write_size, const int write_iters) {
+    int failed = 0;
+    int fd;
+    struct stat sbuf;
+    char ch = 'A';
+    char buf[write_size];
+    char filename[4096];
+    int ret;
+
+    v_printf("s%d i%d\n", write_size, write_iters);
+
+    for (int idx = 0; idx < write_size; idx++) {
+        buf[idx] = ch;
+        ++ch;
+        if (ch > 'z') ch = 'A';
+    }
+
+    strcpy(filename, "files/stat-stat");
+
+    // Create a series of files
+    fd = open(filename, O_RDWR | O_CREAT | O_TRUNC, 0);
+
+    // Make each file a larger size than the one before
+    for (int kdx = 0; kdx < write_iters; kdx++) {
+        write(fd, buf, write_size);
+    }
+
+    ret = unlink(filename);
+    if (ret < 0) {
+        v_printf("ERROR on unlink: %d: %s\n", errno, strerror(errno));
+        ++failed;
+    }
+    ret = fstat(fd, &sbuf);
+    if (ret < 0) {
+        v_printf("ERROR on stat or fstat: %d: %s\n", errno, strerror(errno));
+        ++failed;
+    }
+    else {
+        int expected_size;
+        expected_size = write_size * write_iters;
+
+        // fstat
+        if (sbuf.st_size == expected_size) {
+            v_printf("stat-stat After write, fstat got expected size of %d\n", sbuf.st_size);
+        }
+        else {
+            v_printf("stat-stat After write, fstat ERROR expected %d size is %d\n", expected_size, sbuf.st_size);
+            ++failed;
+        }
+    }
+    close(fd);
+    return failed;
+}
+
+int main(int argc, char *argv[]) {
+    int ret;
+    int opt;
+    int write_size = 32;
+    int write_iters = 16;
+    int failed;
+
+    while ((opt = getopt (argc, argv, "vhf:r:s:i:")) != -1) {
+        switch (opt)
+        {
+            case 'v':
+                verbose = true;
+                break;
+            case 's':
+                write_size = strtol(optarg, NULL, 10);
+                break;
+            case 'i':
+                write_iters = strtol(optarg, NULL, 10);
+                break;
+            case 'h':
+            case '?':
+            default:
+                usage ();
+        }
+    }
+
+    failed = process(write_size, write_iters);
+    if (failed > 0) {
+        printf("FAIL: failures %d\n", failed);
+    }
+    else {
+        printf("PASS:\n");
+    }
+}

--- a/tests/stat-fstat.c
+++ b/tests/stat-fstat.c
@@ -1,0 +1,111 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+static bool verbose = false;
+
+static void usage() {
+    printf("One arg, -v for verbose\n");
+    exit(0);
+}
+
+static void v_printf(const char *fmt, ...) {
+    if (verbose) {
+        va_list ap;
+        va_start(ap, fmt);
+        vfprintf(stdout, fmt, ap);
+        va_end(ap);
+    }
+}
+
+int process(const int write_size, const int write_iters) {
+    int failed = 0;
+    int fd;
+    struct stat sbuf;
+    char ch = 'A';
+    char buf[write_size];
+    char filename[4096];
+    int ret;
+
+    v_printf("s%d i%d\n", write_size, write_iters);
+
+    for (int idx = 0; idx < write_size; idx++) {
+        buf[idx] = ch;
+        ++ch;
+        if (ch > 'z') ch = 'A';
+    }
+
+    strcpy(filename, "files/stat-stat");
+
+    // Create a series of files
+    fd = open(filename, O_RDWR | O_CREAT | O_TRUNC, 0);
+
+    // Make each file a larger size than the one before
+    for (int kdx = 0; kdx < write_iters; kdx++) {
+        write(fd, buf, write_size);
+    }
+
+    ret = fstat(fd, &sbuf);
+    if (ret < 0) {
+        v_printf("ERROR on stat or fstat: %d: %s\n", errno, strerror(errno));
+        ++failed;
+    }
+    else {
+        int expected_size;
+        expected_size = write_size * write_iters;
+
+        // fstat
+        if (sbuf.st_size == expected_size) {
+            v_printf("stat-stat After write, fstat got expected size of %d\n", sbuf.st_size);
+        }
+        else {
+            v_printf("stat-stat After write, fstat ERROR expected %d size is %d\n", expected_size, sbuf.st_size);
+            ++failed;
+        }
+    }
+    close(fd);
+    return failed;
+}
+
+int main(int argc, char *argv[]) {
+    int ret;
+    int opt;
+    int write_size = 32;
+    int write_iters = 16;
+    int failed;
+
+    while ((opt = getopt (argc, argv, "vhf:r:s:i:")) != -1) {
+        switch (opt)
+        {
+            case 'v':
+                verbose = true;
+                break;
+            case 's':
+                write_size = strtol(optarg, NULL, 10);
+                break;
+            case 'i':
+                write_iters = strtol(optarg, NULL, 10);
+                break;
+            case 'h':
+            case '?':
+            default:
+                usage ();
+        }
+    }
+
+    failed = process(write_size, write_iters);
+    if (failed > 0) {
+        printf("FAIL: failures %d\n", failed);
+    }
+    else {
+        printf("PASS:\n");
+    }
+}

--- a/tests/stat-stat-unlink.c
+++ b/tests/stat-stat-unlink.c
@@ -1,0 +1,116 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+static bool verbose = false;
+
+static void usage() {
+    printf("One arg, -v for verbose\n");
+    exit(0);
+}
+
+static void v_printf(const char *fmt, ...) {
+    if (verbose) {
+        va_list ap;
+        va_start(ap, fmt);
+        vfprintf(stdout, fmt, ap);
+        va_end(ap);
+    }
+}
+
+int process(const int write_size, const int write_iters) {
+    int failed = 0;
+    int fd;
+    struct stat sbuf;
+    char ch = 'A';
+    char buf[write_size];
+    char filename[4096];
+    int ret;
+
+    v_printf("s%d i%d\n", write_size, write_iters);
+
+    for (int idx = 0; idx < write_size; idx++) {
+        buf[idx] = ch;
+        ++ch;
+        if (ch > 'z') ch = 'A';
+    }
+
+    strcpy(filename, "files/stat-stat");
+
+    // Create a series of files
+    fd = open(filename, O_RDWR | O_CREAT | O_TRUNC, 0);
+
+    // Make each file a larger size than the one before
+    for (int kdx = 0; kdx < write_iters; kdx++) {
+        write(fd, buf, write_size);
+    }
+
+    ret = unlink(filename);
+    if (ret < 0) {
+        v_printf("ERROR on unlink: %d: %s\n", errno, strerror(errno));
+        ++failed;
+    }
+    ret = stat(filename, &sbuf);
+    if (ret < 0) {
+        v_printf("ERROR on stat or fstat: %d: %s\n", errno, strerror(errno));
+        ++failed;
+    }
+    else {
+        int expected_size;
+        expected_size = write_size * write_iters;
+
+        // fstat
+        if (sbuf.st_size == expected_size) {
+            v_printf("stat-stat After write, fstat got expected size of %d\n", sbuf.st_size);
+        }
+        else {
+            v_printf("stat-stat After write, fstat ERROR expected %d size is %d\n", expected_size, sbuf.st_size);
+            ++failed;
+        }
+    }
+    close(fd);
+    return failed;
+}
+
+int main(int argc, char *argv[]) {
+    int ret;
+    int opt;
+    int write_size = 32;
+    int write_iters = 16;
+    int failed;
+
+    while ((opt = getopt (argc, argv, "vhf:r:s:i:")) != -1) {
+        switch (opt)
+        {
+            case 'v':
+                verbose = true;
+                break;
+            case 's':
+                write_size = strtol(optarg, NULL, 10);
+                break;
+            case 'i':
+                write_iters = strtol(optarg, NULL, 10);
+                break;
+            case 'h':
+            case '?':
+            default:
+                usage ();
+        }
+    }
+
+    failed = process(write_size, write_iters);
+    if (failed > 0) {
+        printf("FAIL: failures %d\n", failed);
+    }
+    else {
+        printf("PASS:\n");
+    }
+}

--- a/tests/stat-stat.c
+++ b/tests/stat-stat.c
@@ -1,0 +1,112 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+static bool verbose = false;
+
+static void usage() {
+    printf("One arg, -v for verbose\n");
+    exit(0);
+}
+
+static void v_printf(const char *fmt, ...) {
+    if (verbose) {
+        va_list ap;
+        va_start(ap, fmt);
+        vfprintf(stdout, fmt, ap);
+        va_end(ap);
+    }
+}
+
+int process(const int write_size, const int write_iters) {
+    int failed = 0;
+    int fd;
+    struct stat sbuf;
+    char ch = 'A';
+    char buf[write_size];
+    char filename[4096];
+    int ret;
+
+    v_printf("s%d i%d\n", write_size, write_iters);
+
+    for (int idx = 0; idx < write_size; idx++) {
+        buf[idx] = ch;
+        ++ch;
+        if (ch > 'z') ch = 'A';
+    }
+
+    strcpy(filename, "files/stat-stat");
+
+    // Create a series of files
+    fd = open(filename, O_RDWR | O_CREAT | O_TRUNC, 0);
+
+    // Make each file a larger size than the one before
+    for (int kdx = 0; kdx < write_iters; kdx++) {
+        write(fd, buf, write_size);
+    }
+
+    ret = stat(filename, &sbuf);
+    // ret = fstat(fd, &sbuf[idx]);
+    if (ret < 0) {
+        v_printf("ERROR on stat or fstat: %d: %s\n", errno, strerror(errno));
+        ++failed;
+    }
+    else {
+        int expected_size;
+        expected_size = write_size * write_iters;
+
+        // fstat
+        if (sbuf.st_size == expected_size) {
+            v_printf("stat-stat After write, fstat got expected size of %d\n", sbuf.st_size);
+        }
+        else {
+            v_printf("stat-stat After write, fstat ERROR expected %d size is %d\n", expected_size, sbuf.st_size);
+            ++failed;
+        }
+    }
+    close(fd);
+    return failed;
+}
+
+int main(int argc, char *argv[]) {
+    int ret;
+    int opt;
+    int write_size = 32;
+    int write_iters = 16;
+    int failed;
+
+    while ((opt = getopt (argc, argv, "vhf:r:s:i:")) != -1) {
+        switch (opt)
+        {
+            case 'v':
+                verbose = true;
+                break;
+            case 's':
+                write_size = strtol(optarg, NULL, 10);
+                break;
+            case 'i':
+                write_iters = strtol(optarg, NULL, 10);
+                break;
+            case 'h':
+            case '?':
+            default:
+                usage ();
+        }
+    }
+
+    failed = process(write_size, write_iters);
+    if (failed > 0) {
+        printf("FAIL: failures %d\n", failed);
+    }
+    else {
+        printf("PASS:\n");
+    }
+}

--- a/tests/stat-vs-fstat.c
+++ b/tests/stat-vs-fstat.c
@@ -1,0 +1,138 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+static bool verbose = false;
+
+static void usage() {
+    printf("One arg, -v for verbose\n");
+    exit(0);
+}
+
+static void v_printf(const char *fmt, ...) {
+    if (verbose) {
+        va_list ap;
+        va_start(ap, fmt);
+        vfprintf(stdout, fmt, ap);
+        va_end(ap);
+    }
+}
+
+int process(const int rounds, const int num_files, const int write_size, const int write_iters) {
+    int failed = 0;
+    int fd[num_files];
+    struct stat fsbuf[num_files];
+    struct stat sbuf[num_files];
+    char ch = 'A';
+    char buf[write_size];
+    char basename[4096];
+    char filename[4096];
+    int sret;
+    int fsret;
+
+    v_printf("r%d n%d s%d i%d\n", rounds, num_files, write_size, write_iters);
+
+    for (int idx = 0; idx < write_size; idx++) {
+        buf[idx] = ch;
+        ++ch;
+        if (ch > 'z') ch = 'A';
+    }
+
+    strcpy(basename, "files/stat-vs-fstat-");
+
+    // Create a series of files
+    for (int idx = 1; idx <= num_files; idx++) {
+        sprintf(filename, "%s%d", basename, idx-1);
+        fd[idx] = open(filename, O_RDWR | O_CREAT | O_TRUNC, 0);
+
+        // Make each file a larger size than the one before
+        for (int kdx = 0; kdx < write_iters; kdx++) {
+            write(fd[idx], buf, idx * write_size);
+        }
+    }
+    for (int idx = 1; idx <= num_files; idx++) {
+        sprintf(filename, "%s%d", basename, idx);
+        fsret = fstat(fd[idx], &fsbuf[idx]);
+        // sret = stat(filename, &sbuf[idx]);
+        if (fsret < 0 || sret < 0) {
+            v_printf("ERROR on stat or fstat\n");
+            ++failed;
+        }
+        else {
+            int expected_size;
+            expected_size = idx * write_size * write_iters;
+
+            // fstat
+            if (fsbuf[idx].st_size == expected_size) {
+                v_printf("stat-vs-fstat-%d After write, fstat got expected size of %d\n", idx, fsbuf[idx].st_size);
+            }
+            else {
+                v_printf("stat-vs-fstat-%d After write, fstat ERROR expected %d size is %d\n", idx, expected_size, fsbuf[idx].st_size);
+                ++failed;
+            }
+   
+            /*
+            // stat
+            if (sbuf[idx].st_size == expected_size) {
+                v_printf("stat-vs-fstat-%d After write, stat got expected size of %d\n", idx, sbuf[idx].st_size);
+            }
+            else {
+                v_printf("stat-vs-fstat-%d After write, stat ERROR expected %d size is %d\n", idx, expected_size, sbuf[idx].st_size);
+                ++failed;
+            }
+            */
+        }
+        close(fd[idx]);
+    }
+    return failed;
+}
+
+int main(int argc, char *argv[]) {
+    int ret;
+    int opt;
+    int num_files = 8; // default for unit test
+    int rounds = 8;
+    int write_size = 32;
+    int write_iters = 16;
+    int failed;
+
+    while ((opt = getopt (argc, argv, "vhf:r:s:i:")) != -1) {
+        switch (opt)
+        {
+            case 'v':
+                verbose = true;
+                break;
+            case 'f':
+                num_files = strtol(optarg, NULL, 10);
+                break;
+            case 'r':
+                rounds = strtol(optarg, NULL, 10);
+                break;
+            case 's':
+                write_size = strtol(optarg, NULL, 10);
+                break;
+            case 'i':
+                write_iters = strtol(optarg, NULL, 10);
+                break;
+            case 'h':
+            case '?':
+            default:
+                usage ();
+        }
+    }
+
+    failed = process(rounds, num_files, write_size, write_iters);
+    if (failed > 0) {
+        printf("FAIL: failures %d\n", failed);
+    }
+    else {
+        printf("PASS:\n");
+    }
+}


### PR DESCRIPTION
* Some sites fill up their file cache; early work

* Changes to get things to compile

* If using shortnames for base, use domain as cluster name as well

* Add logging on attr st_size

* Delete from statcache when replacing in filecache

* Call dav_fgetattr on the file descriptor with fstat

* Reuse common_getattr, but pass in info and make path NULL

* Completed three tasks; about to remove cached_file_size task, but want to keep code

* Remove new code on cached_file_size; is incorrect

* Remove vestiges of test that is no longer applicable

* Some sites fill up their file cache; early work

* If using shortnames for base, use domain as cluster name as well

* Changes to get things to compile

* Add logging on attr st_size

* Delete from statcache when replacing in filecache

* Call dav_fgetattr on the file descriptor with fstat

* Reuse common_getattr, but pass in info and make path NULL

* Completed three tasks; about to remove cached_file_size task, but want to keep code

* Remove new code on cached_file_size; is incorrect

* Remove vestiges of test that is no longer applicable

* Adjust logging