### PR TITLE
[PLAT-906] counters for sainted read and write

### DIFF
--- a/src/filecache.c
+++ b/src/filecache.c
@@ -507,7 +507,7 @@ static void get_fresh_fd(filecache_t *cache,
 
         if (slist) curl_slist_free_all(slist);
 
-        bool non_retriable_error = process_status(funcname, session, res, response_code, elapsed_time, idx, path, false);
+        bool non_retriable_error = process_status("get", session, res, response_code, elapsed_time, idx, path, false);
         // Some errors should not be retried. (Non-errors will fail the
         // for loop test and fall through naturally)
         if (non_retriable_error) break;
@@ -1065,7 +1065,7 @@ static void put_return_etag(const char *path, int fd, char *etag, GError **gerr)
         // also call try_release_request_outstanding. Is this OK?
         session = session_request_init(path, NULL, false);
         if (!session || inject_error(filecache_error_freshsession)) {
-            g_set_error(gerr, curl_quark(), E_FC_CURLERR, "%s: Failed session_request_init on GET", funcname);
+            g_set_error(gerr, curl_quark(), E_FC_CURLERR, "%s: Failed session_request_init on PUT", funcname);
             // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
             try_release_request_outstanding();
             goto finish;
@@ -1090,7 +1090,7 @@ static void put_return_etag(const char *path, int fd, char *etag, GError **gerr)
 
         if (slist) curl_slist_free_all(slist);
 
-        bool non_retriable_error = process_status(funcname, session, res, response_code, elapsed_time, idx, path, false);
+        bool non_retriable_error = process_status("put", session, res, response_code, elapsed_time, idx, path, false);
         // Some errors should not be retried. (Non-errors will fail the
         // for loop test and fall through naturally)
         if (non_retriable_error) break;

--- a/src/filecache.c
+++ b/src/filecache.c
@@ -465,7 +465,7 @@ static void get_fresh_fd(filecache_t *cache,
         if (response_fd >= 0) close(response_fd);
         if (response_filename[0] != '\0') unlink(response_filename);
 
-        session = session_request_init(path, NULL, false);
+        session = session_request_init(path, NULL, false, false);
         if (!session || inject_error(filecache_error_freshsession)) {
             g_set_error(gerr, curl_quark(), E_FC_CURLERR, "%s: Failed session_request_init on GET", funcname);
             // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
@@ -1063,7 +1063,7 @@ static void put_return_etag(const char *path, int fd, char *etag, GError **gerr)
 
         // REVIEW: We didn't use to check for sesssion == NULL, so now we 
         // also call try_release_request_outstanding. Is this OK?
-        session = session_request_init(path, NULL, false);
+        session = session_request_init(path, NULL, false, true);
         if (!session || inject_error(filecache_error_freshsession)) {
             g_set_error(gerr, curl_quark(), E_FC_CURLERR, "%s: Failed session_request_init on PUT", funcname);
             // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.

--- a/src/fusedav.c
+++ b/src/fusedav.c
@@ -299,7 +299,7 @@ static void getdir_propfind_callback(__unused void *userdata, const char *path, 
                 bool tmp_session = true;
                 long elapsed_time = 0;
 
-                if (!(session = session_request_init(path, NULL, tmp_session)) || inject_error(fusedav_error_propfindsession)) {
+                if (!(session = session_request_init(path, NULL, tmp_session, false)) || inject_error(fusedav_error_propfindsession)) {
                     g_set_error(gerr, fusedav_quark(), ENETDOWN, "%s(%s): failed to get request session", funcname, path);
                     // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
                     try_release_request_outstanding();
@@ -1131,7 +1131,7 @@ static void common_unlink(const char *path, bool do_unlink, GError **gerr) {
             struct curl_slist *slist = NULL;
             long elapsed_time = 0;
 
-            if (!(session = session_request_init(path, NULL, false)) || inject_error(fusedav_error_cunlinksession)) {
+            if (!(session = session_request_init(path, NULL, false, true)) || inject_error(fusedav_error_cunlinksession)) {
                 g_set_error(gerr, fusedav_quark(), ENETDOWN, "%s(%s): failed to get request session", funcname, path);
                 // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
                 try_release_request_outstanding();
@@ -1263,7 +1263,7 @@ static int dav_rmdir(const char *path) {
         struct curl_slist *slist = NULL;
         long elapsed_time = 0;
 
-        if (!(session = session_request_init(fn, NULL, false))) {
+        if (!(session = session_request_init(fn, NULL, false, true))) {
             log_print(LOG_ERR, SECTION_FUSEDAV_DIR, "%s(%s): failed to get session", funcname, path);
             // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
             try_release_request_outstanding();
@@ -1338,7 +1338,7 @@ static int dav_mkdir(const char *path, mode_t mode) {
         struct curl_slist *slist = NULL;
         long elapsed_time = 0;
 
-        if (!(session = session_request_init(fn, NULL, false))) {
+        if (!(session = session_request_init(fn, NULL, false, true))) {
             log_print(LOG_ERR, SECTION_FUSEDAV_DIR, "%s(%s): failed to get session", funcname, path);
             // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
             try_release_request_outstanding();
@@ -1431,7 +1431,7 @@ static int dav_rename(const char *from, const char *to) {
         char *escaped_to;
         long elapsed_time = 0;
 
-        if (!(session = session_request_init(from, NULL, false))) {
+        if (!(session = session_request_init(from, NULL, false, true))) {
             log_print(LOG_ERR, SECTION_FUSEDAV_FILE, "%s: failed to get session for %d:%s", funcname, fd, from);
             // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
             try_release_request_outstanding();

--- a/src/props.c
+++ b/src/props.c
@@ -372,6 +372,7 @@ int simple_propfind(const char *path, size_t depth, time_t last_updated, props_r
         void *userdata, GError **gerr) {
     static const char *funcname = "simple_propfind";
     char *description = NULL;
+    asprintf(&description, "%s-propfind", last_updated > 0 ? "progressive" : "complete");
     // Local variables for cURL.
     long response_code = 500; // seed it as bad so we can enter the loop
     CURLcode res = CURLE_OK;
@@ -451,7 +452,7 @@ int simple_propfind(const char *path, size_t depth, time_t last_updated, props_r
         free(query_string);
         query_string = NULL;
 
-        bool non_retriable_error = process_status(funcname, session, res, response_code, elapsed_time, idx, path, false);
+        bool non_retriable_error = process_status(description, session, res, response_code, elapsed_time, idx, path, false);
         // Some errors should not be retried. (Non-errors will fail the
         // for loop test and fall through naturally)
         if (non_retriable_error) break;
@@ -538,8 +539,6 @@ int simple_propfind(const char *path, size_t depth, time_t last_updated, props_r
     ret = 0;
 
 finish:
-    asprintf(&description, "%s-propfinds", last_updated > 0 ? "progressive" : "complete");
-    stats_counter(description, 1, pfsamplerate);
     free(description);
     XML_ParserFree(parser);
     return ret;

--- a/src/props.c
+++ b/src/props.c
@@ -394,7 +394,7 @@ int simple_propfind(const char *path, size_t depth, time_t last_updated, props_r
         if (last_updated > 0) {
             asprintf(&query_string, "changes_since=%lu", last_updated);
         }
-        session = session_request_init(path, query_string, false);
+        session = session_request_init(path, query_string, false, false);
         if (!session || inject_error(props_error_spropfindsession)) {
             g_set_error(gerr, props_quark(), ENETDOWN, "%s(%s): failed to get request session", funcname, path);
             free(query_string);

--- a/src/session.c
+++ b/src/session.c
@@ -264,6 +264,8 @@ static void print_errors(const int iter, const char *type_str, const char *fcn_n
 
     asprintf(&metric_str, "%s.%s", fcn_name, curl_status_str);
     stats_timer(metric_str, elapsed_time);
+    free(metric_str);
+    free(curl_status_str);
     // Don't treat slow requests as 'failures'; it messes up the failure/recovery stats
     if (!slow_request) {
         char *failure_str = NULL;

--- a/src/session.c
+++ b/src/session.c
@@ -1235,7 +1235,7 @@ static CURL *get_session(bool tmp_session) {
     return session;
 }
 
-CURL *session_request_init(const char *path, const char *query_string, bool tmp_session) {
+CURL *session_request_init(const char *path, const char *query_string, bool tmp_session, bool rw) {
     CURL *session;
     char *full_url = NULL;
     char *escaped_path;
@@ -1245,6 +1245,11 @@ CURL *session_request_init(const char *path, const char *query_string, bool tmp_
     // Calls to this function, on detecting this error, set ENETDOWN, which is appropriate
     if (use_saint_mode()) {
         log_print(LOG_NOTICE, SECTION_SESSION_DEFAULT, "%s: already in saint mode", funcname);
+        if (rw) {
+            stats_counter("saint_write", 1, 1.0);
+            return NULL;
+        }
+        stats_counter("saint_read", 1, 1.0);
         return NULL;
     }
 

--- a/src/session.c
+++ b/src/session.c
@@ -239,7 +239,6 @@ static void update_session_count(bool add) {
 static void print_errors(const int iter, const char *type_str, const char *fcn_name, 
         const CURLcode res, const long response_code, const long elapsed_time, const char *path) {
     char *error_str = NULL;
-    char *metric_str = NULL;
     bool slow_request = false;
     float samplerate = 1.0;
 
@@ -1027,8 +1026,7 @@ bool process_status(const char *fcn_name, CURL *session, const CURLcode res,
     bool non_retriable_error = false; // default to retry
     float samplerate = 1.0;
 
-    asprintf(&curl_status_str, "%lu", response_code);
-    char *curl_status_str = NULL;
+    char *metric_str = NULL;
 
     stats_counter("attempts", 1, samplerate);
 

--- a/src/session.c
+++ b/src/session.c
@@ -242,12 +242,13 @@ static void print_errors(const int iter, const char *type_str, const char *fcn_n
     char *metric_str = NULL;
     bool slow_request = false;
     float samplerate = 1.0;
-    char *curl_status_str = "000"
+    const char *curl_empty_status_str = "000";
+    char *curl_status_str = curl_empty_status_str;
 
     if (res != CURLE_OK) {
         asprintf(&error_str, "%s :: %s", curl_errorbuffer(res), "no rc");
     } else if (response_code >= 500) {
-        asprintf(&curl_status_str, "%d", response_code)
+        asprintf(&curl_status_str, "%d", response_code);
         asprintf(&error_str, "%s :: %lu", "no curl error", response_code);
     } else if (elapsed_time >= 0) {
         asprintf(&error_str, "%s :: %lu", "slow_request", elapsed_time);
@@ -261,7 +262,7 @@ static void print_errors(const int iter, const char *type_str, const char *fcn_n
         "%s: curl iter %d on path %s; %s -- fusedav.%s.server-%s.%s",
         fcn_name, iter, path, error_str, filesystem_cluster, nodeaddr, type_str);
 
-    asprintf(&metric_str, "%s.%s", fcn_name, curl_status_str)
+    asprintf(&metric_str, "%s.%s", fcn_name, curl_status_str);
     stats_timer(metric_str, elapsed_time);
     // Don't treat slow requests as 'failures'; it messes up the failure/recovery stats
     if (!slow_request) {

--- a/src/session.h
+++ b/src/session.h
@@ -25,7 +25,7 @@
 extern int num_filesystem_server_nodes;
 
 int session_config_init(char *base, char *ca_cert, char *client_cert, bool grace);
-CURL *session_request_init(const char *path, const char *query_string, bool temporary_handle);
+CURL *session_request_init(const char *path, const char *query_string, bool temporary_handle, bool rw);
 void session_config_free(void);
 bool process_status(const char *fcn_name, CURL *session, const CURLcode res, 
         const long response_code, const long elapsed_time, const int iter, 


### PR DESCRIPTION
Allows us to account for an additional error case where we try to write and fail
because we're in saint mode and a case of graceful degradation where we try to
read but must serve potentially stale data.

Adds the tracking to `session_request_init` by adding a bool to the function
signature for the caller to say whether the request will be a write.