### PR TITLE
[PLAT-906] counters for sainted read and write (#487) (#489)

### DIFF
--- a/src/filecache.c
+++ b/src/filecache.c
@@ -461,7 +461,7 @@ static void get_fresh_fd(filecache_t *cache,
         if (response_fd >= 0) close(response_fd);
         if (response_filename[0] != '\0') unlink(response_filename);
 
-        session = session_request_init(path, NULL, false);
+        session = session_request_init(path, NULL, false, false);
         if (!session || inject_error(filecache_error_freshsession)) {
             g_set_error(gerr, curl_quark(), E_FC_CURLERR, "%s: Failed session_request_init on GET", funcname);
             // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
@@ -503,7 +503,7 @@ static void get_fresh_fd(filecache_t *cache,
 
         if (slist) curl_slist_free_all(slist);
 
-        bool non_retriable_error = process_status(funcname, session, res, response_code, elapsed_time, idx, path, false);
+        bool non_retriable_error = process_status("get", session, res, response_code, elapsed_time, idx, path, false);
         // Some errors should not be retried. (Non-errors will fail the
         // for loop test and fall through naturally)
         if (non_retriable_error) break;
@@ -1059,9 +1059,9 @@ static void put_return_etag(const char *path, int fd, char *etag, GError **gerr)
 
         // REVIEW: We didn't use to check for sesssion == NULL, so now we 
         // also call try_release_request_outstanding. Is this OK?
-        session = session_request_init(path, NULL, false);
+        session = session_request_init(path, NULL, false, true);
         if (!session || inject_error(filecache_error_freshsession)) {
-            g_set_error(gerr, curl_quark(), E_FC_CURLERR, "%s: Failed session_request_init on GET", funcname);
+            g_set_error(gerr, curl_quark(), E_FC_CURLERR, "%s: Failed session_request_init on PUT", funcname);
             // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
             try_release_request_outstanding();
             goto finish;
@@ -1086,7 +1086,7 @@ static void put_return_etag(const char *path, int fd, char *etag, GError **gerr)
 
         if (slist) curl_slist_free_all(slist);
 
-        bool non_retriable_error = process_status(funcname, session, res, response_code, elapsed_time, idx, path, false);
+        bool non_retriable_error = process_status("put", session, res, response_code, elapsed_time, idx, path, false);
         // Some errors should not be retried. (Non-errors will fail the
         // for loop test and fall through naturally)
         if (non_retriable_error) break;

--- a/src/fusedav.c
+++ b/src/fusedav.c
@@ -102,29 +102,12 @@ static int simple_propfind_with_redirect(
         GError **gerr) {
 
     GError *subgerr = NULL;
-    struct timespec start_time;
-    struct timespec now;
-    long elapsed_time;
-    // Alert on propfind taking longer than 4 seconds. This is rather arbitrary.
-    static const unsigned propfind_time_allotment = 4000; // 4 seconds
     int ret;
-    float samplerate = 1.0; // Always sample these stats
 
     log_print(LOG_DEBUG, SECTION_FUSEDAV_STAT, "simple_propfind_with_redirect: Performing (%s) PROPFIND of depth %d on path %s.", 
             last_updated > 0 ? "progressive" : "complete", depth, path);
 
-    clock_gettime(CLOCK_MONOTONIC, &start_time);
     ret = simple_propfind(path, depth, last_updated, result_callback, userdata, &subgerr);
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    elapsed_time = ((now.tv_sec - start_time.tv_sec) * 1000) + ((now.tv_nsec - start_time.tv_nsec) / (1000 * 1000));
-    stats_counter("propfind-count", 1, samplerate);
-    stats_timer("propfind-latency", elapsed_time);
-    if (elapsed_time > propfind_time_allotment) {
-        log_print(LOG_WARNING, SECTION_FUSEDAV_STAT, "simple_propfind_with_redirect: (%s) PROPFIND exceeded time allotment of %u ms; took %u ms.",
-            last_updated > 0 ? "progressive" : "complete", propfind_time_allotment, elapsed_time);
-        stats_counter("exceeded-time-propfind-count", 1, samplerate);
-        stats_timer("exceeded-time-propfind-latency", elapsed_time);
-    }
     if (subgerr) {
         g_propagate_prefixed_error(gerr, subgerr, "simple_propfind_with_redirect: ");
         return ret;
@@ -326,7 +309,7 @@ static void getdir_propfind_callback(__unused void *userdata, const char *path, 
                 bool tmp_session = true;
                 long elapsed_time = 0;
 
-                if (!(session = session_request_init(path, NULL, tmp_session)) || inject_error(fusedav_error_propfindsession)) {
+                if (!(session = session_request_init(path, NULL, tmp_session, false)) || inject_error(fusedav_error_propfindsession)) {
                     g_set_error(gerr, fusedav_quark(), ENETDOWN, "%s(%s): failed to get request session", funcname, path);
                     // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
                     try_release_request_outstanding();
@@ -341,7 +324,7 @@ static void getdir_propfind_callback(__unused void *userdata, const char *path, 
                         "%s: saw %lu; calling HEAD on %s", funcname, status_code, path);
                 timed_curl_easy_perform(session, &res, &response_code, &elapsed_time);
 
-                bool non_retriable_error = process_status(funcname, session, res, response_code, elapsed_time, idx, path, tmp_session);
+                bool non_retriable_error = process_status("propfind-head", session, res, response_code, elapsed_time, idx, path, tmp_session);
                 // Some errors should not be retried. (Non-errors will fail the
                 // for loop test and fall through naturally)
                 if (non_retriable_error) break;
@@ -1170,7 +1153,7 @@ static void common_unlink(const char *path, bool do_unlink, GError **gerr) {
             struct curl_slist *slist = NULL;
             long elapsed_time = 0;
 
-            if (!(session = session_request_init(path, NULL, false)) || inject_error(fusedav_error_cunlinksession)) {
+            if (!(session = session_request_init(path, NULL, false, true)) || inject_error(fusedav_error_cunlinksession)) {
                 g_set_error(gerr, fusedav_quark(), ENETDOWN, "%s(%s): failed to get request session", funcname, path);
                 // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
                 try_release_request_outstanding();
@@ -1302,7 +1285,7 @@ static int dav_rmdir(const char *path) {
         struct curl_slist *slist = NULL;
         long elapsed_time = 0;
 
-        if (!(session = session_request_init(fn, NULL, false))) {
+        if (!(session = session_request_init(fn, NULL, false, true))) {
             log_print(LOG_ERR, SECTION_FUSEDAV_DIR, "%s(%s): failed to get session", funcname, path);
             // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
             try_release_request_outstanding();
@@ -1377,7 +1360,7 @@ static int dav_mkdir(const char *path, mode_t mode) {
         struct curl_slist *slist = NULL;
         long elapsed_time = 0;
 
-        if (!(session = session_request_init(fn, NULL, false))) {
+        if (!(session = session_request_init(fn, NULL, false, true))) {
             log_print(LOG_ERR, SECTION_FUSEDAV_DIR, "%s(%s): failed to get session", funcname, path);
             // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
             try_release_request_outstanding();
@@ -1470,7 +1453,7 @@ static int dav_rename(const char *from, const char *to) {
         char *escaped_to;
         long elapsed_time = 0;
 
-        if (!(session = session_request_init(from, NULL, false))) {
+        if (!(session = session_request_init(from, NULL, false, true))) {
             log_print(LOG_ERR, SECTION_FUSEDAV_FILE, "%s: failed to get session for %d:%s", funcname, fd, from);
             // TODO(kibra): Manually cleaning up this lock sucks. We should make sure this happens in a better way.
             try_release_request_outstanding();

--- a/src/session.h
+++ b/src/session.h
@@ -25,7 +25,7 @@
 extern int num_filesystem_server_nodes;
 
 int session_config_init(char *base, char *ca_cert, char *client_cert, bool grace);
-CURL *session_request_init(const char *path, const char *query_string, bool temporary_handle);
+CURL *session_request_init(const char *path, const char *query_string, bool temporary_handle, bool rw);
 void session_config_free(void);
 bool process_status(const char *fcn_name, CURL *session, const CURLcode res, 
         const long response_code, const long elapsed_time, const int iter, 


### PR DESCRIPTION
* [PLAT-870] Problem: stats for types of requests not distinct

Solution: Account for their number and latency distinctly.

With the Prometheus Statsd exporter in place, we have real histograms that are
fed by `stats_timer`, which means we can ditch related calls to `stats_counter`
and we can just reconfigure the bucket widths in the exporter config rather than
having a const that says how long is too long.

We instrument in `print_errors` because it has the error and latency information
as well as the function name. To that end, I've changed the function name passed
to `process_status` to more closely align with what someone looking at logs or
timeseries might understand because

1) that's easier than more extensive refactoring
2) the other people who care are the ones reading the source and they can just
as easily search for calls to `print_errors`

* move the timers to process_status to observe successes also

* counters for sainted read/write

[PLAT-870]: https://getpantheon.atlassian.net/browse/PLAT-870