### PR TITLE
FS-1111: Track conflicting 404 statistic

### DIFF
--- a/src/filecache.c
+++ b/src/filecache.c
@@ -755,6 +755,7 @@ static void get_fresh_fd(filecache_t *cache,
         struct stat_cache_value *value;
         g_set_error(gerr, filecache_quark(), ENOENT, "%s: File %s expected to exist returns %ld.", 
                 funcname, path, response_code);
+        BUMP(conflicting_404);
         /* we get a 404 because the stat_cache returned that the file existed, but it
          * was not on the server. Deleting it from the stat_cache makes the stat_cache
          * consistent, so the next access to the file will be handled correctly.

--- a/src/stats.h
+++ b/src/stats.h
@@ -46,6 +46,8 @@ struct statistics {
     unsigned propfind_progressive_cache;
     unsigned propfind_complete_cache;
 
+    unsigned conflicting_404;
+
     unsigned filecache_cache_file;
     unsigned filecache_pdata_set;
     unsigned filecache_create_file;


### PR DESCRIPTION
Tracks the number of unexpected (conflicting) 404 errors received when, during normal operation, one binding deletes a file while a separate binding attempts to perform a file operation on the now- deleted file.