### PR TITLE
Increase MAX_DIRENTS_IN_DIR to 200k [FS-1315]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://help.github.com/en/articles/about-code-owners
+
+* @pantheon-systems/filesystem

--- a/src/fusedav.h
+++ b/src/fusedav.h
@@ -22,4 +22,5 @@
 #endif
 
 // Part of https://getpantheon.atlassian.net/browse/FS-1165
-#define MAX_DIRENTS_IN_DIR 100000
+// and https://getpantheon.atlassian.net/browse/FS-1309
+#define MAX_DIRENTS_IN_DIR 200000


### PR DESCRIPTION
Data collection has found ZERO broken directories with 100k-200k files/dirs (dirents).  Raising the warning threshold to 200k (was 100k) dirents will reduce the number of log messages in logz.io, making it easier to find/analyze the real issues.

Also, add CODEOWNERS per best practices.

Next (step 2 of 3): https://github.com/pantheon-systems/cos-runtime-images/pull/122
Final (step 3 of 3): https://github.com/pantheon-systems/titan-mt/pull/19675